### PR TITLE
fix require, make aws-sdk a dep

### DIFF
--- a/bin/lambda-cfn-rules.js
+++ b/bin/lambda-cfn-rules.js
@@ -6,7 +6,7 @@ var queue = require('queue-async');
 var defs = { exports: {} };
 var rules = [];
 
-var lambdaCfn = require('lambda-cfn');
+var lambdaCfn = require('..');
 
 lambdaCfn.load(defs, false, true);
 

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "dependencies": {
     "streambot": "3.4.0",
     "queue-async": "1.0.7",
-    "app-root-path": "1.2.0"
+    "app-root-path": "1.2.0",
+    "aws-sdk": "^2.2.35"
   },
   "devDependencies": {
-    "aws-sdk": "^2.2.35",
     "jscs": "^1.11.3",
     "jshint": "^2.6.3",
     "tape": "^4.5.1"


### PR DESCRIPTION
Fixes a refactor leftover, and makes aws-sdk a dep, which the rules creation script needs.