### PR TITLE
Give rules script its own loader

### DIFF
--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -25,7 +25,7 @@ lambdaCfn.lambdaSnsUserAccessKey = lambdaSnsUserAccessKey;
 lambdaCfn.outputs = outputs;
 lambdaCfn.load = load;
 
-function load(m, templateFilePath, raw) {
+function load(m, templateFilePath) {
   // Configurable for the sake of testing
   var templateFile;
   if (templateFilePath && templateFilePath !== true) {
@@ -48,7 +48,7 @@ function load(m, templateFilePath, raw) {
         template.Resources[r].Metadata.sourcePath) {
       var sourcePath = path.join(root, template.Resources[r].Metadata.sourcePath);
       var rule = require(sourcePath);
-      m.exports[rule.config.name] = raw ? rule : streambot(rule.fn);
+      m.exports[rule.config.name] = streambot(rule.fn);
     }
   }
 }


### PR DESCRIPTION
`load` in lib was overloaded to also handle loading for the script in bin which is used to create cloudwatch rules, but this made the code more complicated, so this PR puts more responsibility in the rules script.