### PR TITLE
Output snstopic name

### DIFF
--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -530,6 +530,12 @@ function outputs(options) {
   if (!options.name) throw new Error('name property required for template outputs');
   if (!options.snsRule) return;
   var output = {};
+
+  output[options.name + 'SNSTopic'] = {
+    "Value": {
+      "Ref": options.name + 'SNSTopic'
+    }
+  };
   output[options.name + 'SNSUserAccessKey'] = {
     "Value": {
       "Ref": options.name + 'SNSUserAccessKey'

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -84,7 +84,8 @@ function build(options) {
   return {
     Parameters: parameters(options),
     Resources: resources,
-    Policy: policy(options)
+    Policy: policy(options),
+    Outputs: outputs(options)
   };
 }
 

--- a/test/lambda-cfn.test.js
+++ b/test/lambda-cfn.test.js
@@ -389,6 +389,7 @@ tape('template outputs unit tests', function(t) {
   var def = outputs({name: 'myHandler'});
   t.equal(def,undefined,'non-snsRules have no outputs');
   def = outputs({name: 'myHandler',snsRule:{}});
+  t.equal(def.myHandlerSNSTopic.Value.Ref,'myHandlerSNSTopic','SNS topic output is set');
   t.equal(def.myHandlerSNSUserAccessKey.Value.Ref,'myHandlerSNSUserAccessKey','User access key output is set');
   t.equal(def.myHandlerSNSUserSecretAccessKey.Value["Fn::GetAtt"][0],'myHandlerSNSUserAccessKey','User secret access key output is set');
   t.end();


### PR DESCRIPTION
This fixes a bug where the template was not building the Outputs section as well as adds the SNSTopic name to the output for easy of use.