### PR TITLE
[WIP] Api gateway support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
 
 ## Unreleased
+- none
 
+## 0.1.0 2016-05-02
+- API Gateway rule support 
+  
 ## 0.0.10 2016-04-22
 - Uses newly released CFN support for Cloudwatch Event Rules
 - Update from `queue-async` to `d3-queue`

--- a/RULE-SPEC.md
+++ b/RULE-SPEC.md
@@ -28,15 +28,34 @@
 	};
 	```
 
-- The rule's `name` in the `config` property must be unique across all rules imported into a single patrol stack, see [issue #15](https://github.com/mapbox/lambda-cfn/issues/15).
 - Lambda runtime parameters for `memorySize` and `timeout` are set per rule and are optional.
     - `memorySize` must a multiple of 64MB between 128MB and 1536MB. If not specified, the default is 128mb.
     - `timeout` can be 0 to 300 seconds. If not specified, the default is 60 seconds.
 - `statements` is an optional array of IAM policy statements which will be added to the Lambda IAM role.  If your Lambda function requires additional AWS API access, specify it here.
 
-## Environment variables and rule parameters
-- Environment variables are passed to the AWS Lambda function's for a patrol rule via CloudFormation template parameters that are sent to a running instance of [streambot](http://github.com/mapbox/streambot).
-- Environment variables can be accessed within a patrol rule via the `process.env` object.
+## Rule parameters and environment variables
+- If a rule specifies parameters in its configuration, [streambot](http://github.com/mapbox/streambot) handles storing the parameters and then loading the parameters into the lambda's environment when it is started.
+- Rule parameters are namespaced and must be accessed from within the lambda function using the lambda-cfn 'getEnv' function.
+- Namespaced parameters use the following format:
+  `process.env` + `repositoryName` + `ruleName` + `parameter` => strip punctuation =>`process.env.patrolrulesgithub2faDisabledgithubToken`
+- Using the `getEnv()` function to retrieve the value of a parameter: 
+  
+  ```javascript
+  var getEnv = require('lambda-cfn').getEnv;
+  ...
+  
+  module.exports.config = {
+  ...
+  
+  parameters: {
+    'someParameter': {
+    ...
+  
+  module.exports.fn = function(event,callback) {
+  var someParameter = getEnv(someParameter);
+  ...
+  ```
+
 - Parameters are optional, but if specified require both a `Type` and a `Description` property.
 
     ```javascript
@@ -48,12 +67,10 @@
 		/* more items */
 	}
     ```
-- Parameter namespace is global across all included rule sets, see [issue #6](https://github.com/mapbox/lambda-cfn/issues/6).
-- AWS Lambda does not natively support passing CloudFormation parameters to lambdas on startup, so [`streambot`](http://github.com/mapbox/streambot) is used to populate the lambda `process.env` with the parameters.
 
 
 ## Rule definitions
-### CloudWatch Event rule
+### CloudWatch Event rule (eventRule, scheduledRule)
 Cloudwatch Event rules support triggering the patrol rule's Lambda function with a CloudWatch Event (`eventRule`) or a scheduled CloudWatch Event (`scheduledRule`). A rule definition can specify an `eventRule`, a `scheduledRule`, or both. If you want the rule to fire on a schedule and on an event filter, but at least one must be present.
 
 See [Using CloudWatch Events](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/WhatIsCloudWatchEvents.html) for more information about AWS CloudWatch Events.
@@ -74,12 +91,12 @@ module.exports.config = {
 };
 ```
 #### Description
-* `name`: Rule name, must be unique across all included rules. **Required.**
+* `name`: Rule name **Required.**
 * `eventRule`,`scheduledRule`: Denotes a CloudWatch Events driven rule. **At least one event type is required.**
 * `eventPattern`: Free-form JSON object pattern used by the rule to match events. **Required.** See [CloudWatch Events and Event Patterns](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CloudWatchEventsandEventPatterns.html).
 * `scheduledRule`: A valid [CloudWatch Events schedule expression](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ScheduledEvents.html)
 
-### SNS subscribed rule
+### SNS subscribed rule (snsRule)
 SNS rules subscribe the lambda function to a unique SNS topic. Events pushed to the topic will trigger the lambda function and will pass the event payload directly to it. `lambda-cfn` creates a unique SNS topic for each SNS rule, and each topic has a unique access and secret key generated for it, found in the template output of the CloudFormation console.
 
 SNS rules allow the integration of non-AWS event sources into Patrol, such as Github and Zapier. Due to  limitations of Zapier, rules of this type are granted the `listTopic` permission for the AWS account. For more information on SNS subscribed lambdas see [Invoking Lambda functions using Amazon SNS notifications](http://docs.aws.amazon.com/sns/latest/dg/sns-lambda.html).
@@ -92,8 +109,76 @@ module.exports.config = {
 };
 ```
 #### Description
-* `name`: Rule name, must be unique across all included rules. **Required.**
+* `name`: Rule name **Required.**
 * `snsRule`: Denotes an SNS subscribed rule. This should be left empty. **Required.**
+
+### API Gateway rule (gatewayRule)
+Gateway rules setup and create a publicly accessible REST endpoint using AWS API Gateway for triggering the lambda. Currently this rule type creates one endpoint that supports one HTTP method per rule. The public endpoint for each gatewayRule can be found in the template output. An API key is created per stack, and restricted to that stack and stage. The default stage created and deployed is named 'prod'. 
+
+The default output mapping outputs a 200 return code for everything but return values matching "Error" or "Exception", which are mapped to 500. 
+
+Each stack creates a single API gateway and a single API key. Rules are bound to namespaced paths
+`/` + `repositoryName` + `ruleName` => strip punctuation => downcase => `/path`
+`/` + `patrol-rules-github` + `madePublic` => `/patrolrulesgithubmadepublic`
+
+#### Example
+```javascript
+module.exports.config = {
+  name: 'STRING_VALUE',      /* required */
+  gatewayRule: {
+    method: 'HTTPMETHOD',    /* required */
+    apiKey: BOOLEAN,         /* optional */
+    methodResponses: [       /* optional */
+      { JSON },
+      ...
+    ],     
+    integrationResponses: [  /* optional */
+      { JSON },
+      ...
+    ] 
+  }
+};
+```
+
+#### Description
+* `name`: Rule name **Required**
+* `gatewayRule`: Denotes a rule with a publicly accessible REST endpoint **Required**
+* `method`: GET|PUT|POST|PATCH|DELETE|HEAD|OPTIONS  Client HTTP method
+* `apiKey`: true|false Client request must use stack's [API key](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html)
+* `methodResponses`: an array of JSON definitions for the [method response mapping](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-methodresponse.html)
+* `integrationResponses`: an array of JSON definitions for the [integration response mapping](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-method-integration-integrationresponse.html)
+
+#### Integration and method response defaults
+Integration response:
+```javascript
+[
+  {
+    "StatusCode": "200"
+  },
+  {
+    "StatusCode": "500",
+    "SelectionPattern": ".*/Error|Exception/.*"
+  }
+],
+```
+
+Method response:
+```javascript
+[
+  {
+    "StatusCode": "200",
+    "ResponseModels": {
+      "application/json": "Empty"
+    }
+  },
+  {
+    "StatusCode": "500",
+    "ResponseModels": {
+      "application/json": "Empty"
+    }
+  }
+],
+```
 
 ## Rule functions
 - `lambda-cfn` binds the function to the Lambda function's `index.RULE_NAME` handler.
@@ -101,3 +186,13 @@ module.exports.config = {
 - When creating a rule that is both event and schedule triggered, the function should first detect the Cloudwatch Event object type (`eventRule` or `scheduledRule`), and act accordingly as schedule and filter event payloads are different.
 - All Lambda functions are wrapped by [`streambot`](http://github.com/mapbox/streambot), and the callback uses the familiar node.js style format of `(err,result)`.
 - The AWS Lambda `context` is bound to the Streambot'ed function as per [pull request #36](https://github.com/mapbox/streambot/pull/36) on streambot.
+
+
+
+
+
+
+
+
+
+

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -26,9 +26,15 @@ lambdaCfn.outputs = outputs;
 lambdaCfn.load = load;
 lambdaCfn.getEnv = getEnv;
 lambdaCfn.cweRules = cweRules;
+lambdaCfn.apiGateway = apiGateway;
+lambdaCfn.apiDeployment = apiDeployment;
+lambdaCfn.apiKey = apiKey;
+lambdaCfn.gatewayRules = gatewayRules;
 
-function stripHyphens(r) {
-    return r.replace(/-/g, '');
+
+
+function stripPunc(r) {
+  return r.replace(/[^A-Za-z0-9]/g,'');
 }
 
 // exported for testing
@@ -43,7 +49,7 @@ function namespace(name,path) {
   var namePrefix;
   for (var pkg in pkgs.dependencies) {
     if (path.match(pkg)) {
-      namePrefix = stripHyphens(pkg);
+      namePrefix = stripPunc(pkg);
       break;
     }
   }
@@ -100,7 +106,7 @@ function embed(lambdaPaths, template) {
 
   return template;
 }
-
+// builds template parts for a single rule
 function build(options) {
   var resources = {};
   resources[options.name] = lambda(options);
@@ -112,10 +118,14 @@ function build(options) {
     resources[options.name + 'SNSUserAccessKey'] = lambdaSnsUserAccessKey(options);
   }
   if (options.eventRule) {
-    resources[options.name + 'eventRule'] = cweRules(options,'eventRule');
+    resources[options.name + 'EventRule'] = cweRules(options,'eventRule');
   }
   if (options.scheduledRule) {
     resources[options.name + 'ScheduledRule'] = cweRules(options,'scheduledRule');
+  }
+  if (options.gatewayRule) {
+    resources[options.name + 'GatewayRuleResource'] = gatewayRules(options,'resource');
+    resources[options.name + 'GatewayRuleMethod'] = gatewayRules(options,'method');
   }
   var alarms = cloudwatch(options);
   for (var k in alarms) {
@@ -130,6 +140,7 @@ function build(options) {
   };
 }
 
+// builds all rule template parts into a template
 function compile(parts, template) {
   if (!Array.isArray(parts)) throw new Error('parts must be an array');
   if (!template.AWSTemplateFormatVersion)
@@ -162,6 +173,7 @@ function compile(parts, template) {
     Description: 'Alarm notifications will send to this email address'
   };
 
+  var apiDeploymentDependsOn = [];
   parts.forEach(function(part) {
     // Parameters
     if (part.Parameters) {
@@ -175,6 +187,21 @@ function compile(parts, template) {
     // Resources
     if (part.Resources) {
       for (var r in part.Resources) {
+        if (r.match('GatewayRuleMethod')) {
+          if (!template.Resources.ApiGateway) {
+            template.Resources.ApiGateway = apiGateway();
+            template.Resources.ApiKey = apiKey();
+            template.Resources.ApiLatencyAlarm = apiLatencyAlarm();
+            template.Resources.Api4xxAlarm = api4xxAlarm();
+            template.Resources.ApiCountAlarm = apiCountAlarm();
+            template.Outputs.APIKey = {
+              "Value": {
+                "Ref": "ApiKey"
+              }
+            };
+          }
+          apiDeploymentDependsOn.push(r);
+        }
         if (template.Resources[r])
           throw new Error('Duplicate resource key' + r);
         template.Resources[r] = part.Resources[r];
@@ -200,7 +227,9 @@ function compile(parts, template) {
 
   // Alarm SNS topic
   template.Resources.LambdaCfnAlarmSNSTopic = snsTopic();
-
+  if (template.Resources.ApiGateway) {
+    template.Resources.ApiDeployment = apiDeployment(apiDeploymentDependsOn);
+  }
   return template;
 
 }
@@ -212,7 +241,7 @@ function parameters(options) {
       throw new Error('Parameter must contain Type property');
     if (!options.parameters[p].Description)
       throw new Error('Parameter must contain Description property');
-    namespacedParameters[stripHyphens(options.name) + p] = options.parameters[p];
+    namespacedParameters[stripPunc(options.name) + p] = options.parameters[p];
   }
   return namespacedParameters;
 }
@@ -304,7 +333,6 @@ function cweRules(options,ruleType) {
 
 }
 
-
 function lambda(options) {
   if (!options.name) throw new Error('name property required for lambda');
   var fn = {
@@ -395,6 +423,40 @@ function lambdaPermission(options) {
         }
       }
     };
+  } else if (options.gatewayRule) {
+    perm = {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            options.name,
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGateway"
+              },
+              "/*"
+            ]
+          ]
+        }
+      }
+    };
   } else {
     perm = {
       "Type": "AWS::Lambda::Permission",
@@ -434,6 +496,251 @@ function lambdaPermission(options) {
   return perm;
 
 }
+
+function apiGateway() {
+  return {
+    "Type": "AWS::ApiGateway::RestApi",
+    "Properties": {
+      "Name": {
+        "Ref": "AWS::StackName"
+      },
+      "FailOnWarnings": "true"
+    }
+  };
+}
+
+
+function apiDeployment(dependsOn) {
+  var apiDeploy =  {
+    "Type": "AWS::ApiGateway::Deployment",
+    "DependsOn": dependsOn,
+    "Properties": {
+      "RestApiId": {
+        "Ref": "ApiGateway"
+      },
+      "StageName": "prod",
+      "StageDescription": {
+        "StageName": "prod"
+      }
+    }
+  };
+  return apiDeploy;
+}
+
+function apiKey() {
+  return {
+    "Type": "AWS::ApiGateway::ApiKey",
+    "DependsOn": "ApiDeployment",
+    "Properties": {
+      "Name": {
+        "Ref": "AWS::StackName"
+      },
+      "Enabled": "true",
+      "StageKeys": [
+        {
+          "RestApiId": {
+            "Ref": "ApiGateway"
+          },
+          "StageName": "prod"
+        }
+      ]
+    }
+  };
+}
+
+function apiLatencyAlarm() {
+  return {
+    "Type": "AWS::CloudWatch::Alarm",
+    "Properties": {
+      "EvaluationPeriods": "5",
+      "Statistic": "Sum",
+      "Threshold": "4",
+      "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#ApiLatencyAlarm",
+      "Period": "60",
+      "AlarmActions": [
+        {
+          "Ref": "LambdaCfnAlarmSNSTopic"
+        }
+      ],
+      "Namespace": "AWS/ApiGateway",
+      "Dimensions": [
+        {
+          "Name": "APIName",
+          "Value": {
+            "Ref": "AWS::StackName"
+          }
+        }
+      ],
+      "ComparisonOperator": "GreaterThanThreshold",
+      "MetricName": "Latency"
+    }
+  };
+}
+
+function api4xxAlarm() {
+  return {
+    "Type": "AWS::CloudWatch::Alarm",
+    "Properties": {
+      "EvaluationPeriods": "5",
+      "Statistic": "Sum",
+      "Threshold": "100",
+      "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#Api4xxAlarm",
+      "Period": "60",
+      "AlarmActions": [
+        {
+          "Ref": "LambdaCfnAlarmSNSTopic"
+        }
+      ],
+      "Namespace": "AWS/ApiGateway",
+      "Dimensions": [
+        {
+          "Name": "APIName",
+          "Value": {
+            "Ref": "AWS::StackName"
+          }
+        }
+      ],
+      "ComparisonOperator": "GreaterThanThreshold",
+      "MetricName": "4xxError"
+    }
+  };
+}
+
+function apiCountAlarm() {
+  return {
+    "Type": "AWS::CloudWatch::Alarm",
+    "Properties": {
+      "EvaluationPeriods": "5",
+      "Statistic": "Sum",
+      "Threshold": "10000",
+      "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#ApiCountAlarm",
+      "Period": "60",
+      "AlarmActions": [
+        {
+          "Ref": "LambdaCfnAlarmSNSTopic"
+        }
+      ],
+      "Namespace": "AWS/ApiGateway",
+      "Dimensions": [
+        {
+          "Name": "APIName",
+          "Value": {
+            "Ref": "AWS::StackName"
+          }
+        }
+      ],
+      "ComparisonOperator": "GreaterThanThreshold",
+      "MetricName": "Count"
+    }
+  };
+}
+
+function gatewayRules(options,apiPart) {
+  if (!options.name) throw new Error('name property required for gateway rule');
+  if (!apiPart) throw new Error('resource type required for gateway rule template');
+  if (/resource|method/.test(apiPart) == false) {
+    throw new Error('Invalid api gateway resource type');
+  }
+  if (/GET|HEAD|PUT|PATCH|OPTIONS|POST|DELETE/.test(options.gatewayRule.method.toUpperCase()) == false) {
+    throw new Error('Invalid client HTTP method specified: ' + options.gatewayRule.method);
+  }
+  var apiTemplate = {};
+  if (apiPart == 'resource') {
+    return {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGateway",
+            "RootResourceId"
+          ]
+        },
+        "RestApiId": {
+          "Ref": "ApiGateway"
+        },
+        "PathPart": options.name.toLowerCase()
+      }
+    };
+  }
+  if (apiPart == 'method') {
+    if (options.gatewayRule.methodResponses && Array.isArray(options.gatewayRule.methodResponses)) {
+    } else {
+      options.gatewayRule.methodResponses = [
+        {
+          "StatusCode": "200",
+          "ResponseModels": {
+            "application/json": "Empty"
+          }
+        },
+        {
+          "StatusCode": "500",
+          "ResponseModels": {
+            "application/json": "Empty"
+          }
+        }
+      ];
+    }
+
+    if (options.gatewayRule.integrationResponses && Array.isArray(options.gatewayRule.integrationResponses)) {
+    } else {
+      options.gatewayRule.integrationResponses = [
+        {
+          "StatusCode":"200"
+        },
+        {
+          "StatusCode":"500",
+          "SelectionPattern": ".*/Error|Exception/.*"
+        }
+      ];
+    }
+
+    apiTemplate = {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiGateway"
+        },
+        "ResourceId": {
+          "Ref": options.name + 'GatewayRuleResource'
+        },
+        "AuthorizationType": "None",
+        "HttpMethod": options.gatewayRule.method.toUpperCase(),
+        "MethodResponses": options.gatewayRule.methodResponses,
+        "Integration": {
+          "Type": "AWS",
+          "IntegrationHttpMethod": "POST",
+          "IntegrationResponses": options.gatewayRule.integrationResponses,
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt":
+                  [
+                    options.name,
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        }
+      }
+    };
+
+    if (options.gatewayRule.apiKey) {
+      apiTemplate.Properties.ApiKeyRequired = "true";
+    }
+  }
+  return apiTemplate;
+}
+
 
 function lambdaSnsUser(options) {
   if (!options.name) throw new Error('name property required for lambda SNS User');
@@ -566,6 +873,14 @@ function role() {
             "Sid": "",
             "Effect": "Allow",
             "Principal": {
+              "Service": "apigateway.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          },
+          {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
               "Service": "events.amazonaws.com"
             },
             "Action": "sts:AssumeRole"
@@ -660,27 +975,49 @@ function policy(options) {
 
 function outputs(options) {
   if (!options.name) throw new Error('name property required for template outputs');
-  if (!options.snsRule) return;
   var output = {};
 
-  output[options.name + 'SNSTopic'] = {
-    "Value": {
-      "Ref": options.name + 'SNSTopic'
-    }
-  };
-  output[options.name + 'SNSUserAccessKey'] = {
-    "Value": {
-      "Ref": options.name + 'SNSUserAccessKey'
-    }
-  };
-  output[options.name + 'SNSUserSecretAccessKey'] = {
-    "Value": {
-      "Fn::GetAtt": [
-        options.name + 'SNSUserAccessKey',
-        "SecretAccessKey"
-      ]
-    }
-  };
+  if (options.snsRule) {
+    output[options.name + 'SNSTopic'] = {
+      "Value": {
+        "Ref": options.name + 'SNSTopic'
+      }
+    };
+    output[options.name + 'SNSUserAccessKey'] = {
+      "Value": {
+        "Ref": options.name + 'SNSUserAccessKey'
+      }
+    };
+    output[options.name + 'SNSUserSecretAccessKey'] = {
+      "Value": {
+        "Fn::GetAtt": [
+          options.name + 'SNSUserAccessKey',
+          "SecretAccessKey"
+        ]
+      }
+    };
+  }
+  if (options.gatewayRule) {
+    output[options.name + 'APIEndpoint'] = {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "ApiGateway"
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region"
+            },
+            ".amazonaws.com/prod/",
+            options.name.toLowerCase()
+          ]
+        ]
+      }
+    };
+  }
 
   return output;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-cfn",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "CloudFormation boiler plate for lambda functions",
   "main": "lib/lambda-cfn.js",
   "engines": {
@@ -20,9 +20,7 @@
     "streambot": "3.4.0",
     "d3-queue": "^2.0.3",
     "app-root-path": "1.2.0",
-    "aws-sdk": "^2.2.35",
-    "yargs": "^4.6.0",
-    "inquirer": "^1.0.0"
+    "aws-sdk": "^2.2.35"
   },
   "devDependencies": {
     "jscs": "^1.11.3",

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -16,6 +16,7 @@ tape('Compile unit tests', function(t) {
   })], {});
 
   var simpleFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/simple.template'), "utf8"));
+
   t.deepEqual(simpleBuilt, simpleFixture, 'simple build is equal to fixture');
 
   var fullConfig = {
@@ -66,6 +67,7 @@ tape('Compile SNS rule', function(t) {
 
   var snsBuilt = lambdaCfn.compile([lambdaCfn.build(snsConfig)], {});
   var snsFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/sns.template'), "utf8"));
+
   t.deepEqual(snsBuilt,snsFixture, 'SNS rule build is equal to fixture');
 
   t.end();
@@ -105,6 +107,7 @@ tape('Compile Event rule', function(t) {
 
   var eventBuilt = lambdaCfn.compile([lambdaCfn.build(eventConfig)], {});
   var eventFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/event.template'), "utf8"));
+
   t.deepEqual(eventBuilt,eventFixture, 'Event rule build is equal to fixture');
 
   t.end();
@@ -125,6 +128,7 @@ tape('Compile Scheduled rule', function(t) {
 
   var scheduledBuilt = lambdaCfn.compile([lambdaCfn.build(scheduledConfig)], {});
   var scheduledFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/scheduled.template'), "utf8"));
+
   t.deepEqual(scheduledBuilt,scheduledFixture, 'Scheduled rule build is equal to fixture');
 
   t.end();
@@ -165,7 +169,30 @@ tape('Compile Hybrid Scheduled and Hybrid based rule', function(t) {
 
   var hybridBuilt = lambdaCfn.compile([lambdaCfn.build(hybridConfig)], {});
   var hybridFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/hybrid.template'), "utf8"));
-  t.deepEqual(hybridBuilt,hybridFixture, 'Hybrid rule build is equal to fixture');
+  t.deepLooseEqual(hybridBuilt,hybridFixture, 'Hybrid rule build is equal to fixture');
 
+  t.end();
+});
+
+tape('Compile ApiGateway based rule', function(t) {
+  var gatewayConfig = {
+    name: 'gatewayTestRule',
+    sourcePath: 'test/rules/gatewayTestRule.js',
+    parameters: {
+      'token': {
+        'Type': 'String',
+        'Description': 'token'
+      }
+    },
+    gatewayRule: {
+      method: "POST",
+      apiKey: true
+    }
+  };
+
+  var gatewayBuilt = lambdaCfn.compile([lambdaCfn.build(gatewayConfig)], {});
+  var gatewayFixture = JSON.parse(fs.readFileSync(path.join(__dirname,'./fixtures/gateway.template'),"utf8"));
+
+  t.deepLooseEqual(gatewayBuilt,gatewayFixture, 'Gateway rule build is equal to fixture');
   t.end();
 });

--- a/test/fixtures/event.template
+++ b/test/fixtures/event.template
@@ -118,7 +118,7 @@
                 }
             }
         },
-        "eventRuleeventRule": {
+        "eventRuleEventRule": {
             "Type": "AWS::Events::Rule",
             "Properties": {
                 "EventPattern": {
@@ -232,6 +232,14 @@
                             "Effect": "Allow",
                             "Principal": {
                                 "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        },
+                        {
+                            "Sid": "",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "apigateway.amazonaws.com"
                             },
                             "Action": "sts:AssumeRole"
                         },

--- a/test/fixtures/gateway.template
+++ b/test/fixtures/gateway.template
@@ -22,17 +22,13 @@
             "Type": "String",
             "Description": "Alarm notifications will send to this email address"
         },
-        "fullgithubToken": {
+        "gatewayTestRuletoken": {
             "Type": "String",
-            "Description": "Github API token with users scope"
-        },
-        "fullmyBucket": {
-            "Type": "String",
-            "Description": "Bucket where to store"
+            "Description": "token"
         }
     },
     "Resources": {
-        "full": {
+        "gatewayTestRule": {
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Code": {
@@ -63,31 +59,31 @@
                 "Description": {
                     "Ref": "AWS::StackName"
                 },
-                "Handler": "index.full",
+                "Handler": "index.gatewayTestRule",
                 "Runtime": "nodejs",
                 "Timeout": 60,
                 "MemorySize": 128
             },
             "Metadata": {
-                "sourcePath": "rules/myRule.js"
+                "sourcePath": "test/rules/gatewayTestRule.js"
             }
         },
-        "fullPermission": {
+        "gatewayTestRulePermission": {
             "Type": "AWS::Lambda::Permission",
             "Properties": {
                 "FunctionName": {
                     "Fn::GetAtt": [
-                        "full",
+                        "gatewayTestRule",
                         "Arn"
                     ]
                 },
                 "Action": "lambda:InvokeFunction",
-                "Principal": "events.amazonaws.com",
+                "Principal": "apigateway.amazonaws.com",
                 "SourceArn": {
                     "Fn::Join": [
                         "",
                         [
-                            "arn:aws:events:",
+                            "arn:aws:execute-api:",
                             {
                                 "Ref": "AWS::Region"
                             },
@@ -95,37 +91,227 @@
                             {
                                 "Ref": "AWS::AccountId"
                             },
-                            ":rule/",
+                            ":",
                             {
-                                "Ref": "AWS::StackName"
+                                "Ref": "ApiGateway"
                             },
-                            "*"
+                            "/*"
                         ]
                     ]
                 }
             }
         },
-        "StreambotEnvfull": {
+        "StreambotEnvgatewayTestRule": {
             "Type": "Custom::StreambotEnv",
             "Properties": {
                 "ServiceToken": {
                     "Ref": "StreambotEnv"
                 },
                 "FunctionName": {
-                    "Ref": "full"
+                    "Ref": "gatewayTestRule"
                 },
-                "fullgithubToken": {
-                    "Ref": "fullgithubToken"
-                },
-                "fullmyBucket": {
-                    "Ref": "fullmyBucket"
+                "gatewayTestRuletoken": {
+                    "Ref": "gatewayTestRuletoken"
                 },
                 "LambdaCfnAlarmSNSTopic": {
                     "Ref": "LambdaCfnAlarmSNSTopic"
                 }
             }
         },
-        "fullAlarmErrors": {
+        "ApiGateway": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Properties": {
+                "Name": {
+                    "Ref": "AWS::StackName"
+                },
+                "FailOnWarnings": "true"
+            }
+        },
+        "ApiKey": {
+            "Type": "AWS::ApiGateway::ApiKey",
+            "DependsOn": "ApiDeployment",
+            "Properties": {
+                "Name": {
+                    "Ref": "AWS::StackName"
+                },
+                "Enabled": "true",
+                "StageKeys": [
+                    {
+                        "RestApiId": {
+                            "Ref": "ApiGateway"
+                        },
+                        "StageName": "prod"
+                    }
+                ]
+            }
+        },
+        "ApiDeployment": {
+            "Type": "AWS::ApiGateway::Deployment",
+            "DependsOn": [ "gatewayTestRuleGatewayRuleMethod" ],
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGateway"
+                },
+                "StageName": "prod",
+                "StageDescription": {
+                    "StageName": "prod"
+                }
+            }
+        },
+        "ApiLatencyAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "EvaluationPeriods": "5",
+                "Statistic": "Sum",
+                "Threshold": "4",
+                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#ApiLatencyAlarm",
+                "Period": "60",
+                "AlarmActions": [
+                    {
+                        "Ref": "LambdaCfnAlarmSNSTopic"
+                    }
+                ],
+                "Namespace": "AWS/ApiGateway",
+                "Dimensions": [
+                    {
+                        "Name": "APIName",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    }
+                ],
+                "ComparisonOperator": "GreaterThanThreshold",
+                "MetricName": "Latency"
+            }
+        },
+        "Api4xxAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "EvaluationPeriods": "5",
+                "Statistic": "Sum",
+                "Threshold": "100",
+                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#Api4xxAlarm",
+                "Period": "60",
+                "AlarmActions": [
+                    {
+                        "Ref": "LambdaCfnAlarmSNSTopic"
+                    }
+                ],
+                "Namespace": "AWS/ApiGateway",
+                "Dimensions": [
+                    {
+                        "Name": "APIName",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    }
+                ],
+                "ComparisonOperator": "GreaterThanThreshold",
+                "MetricName": "4xxError"
+            }
+        },
+        "ApiCountAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "EvaluationPeriods": "5",
+                "Statistic": "Sum",
+                "Threshold": "10000",
+                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#ApiCountAlarm",
+                "Period": "60",
+                "AlarmActions": [
+                    {
+                        "Ref": "LambdaCfnAlarmSNSTopic"
+                    }
+                ],
+                "Namespace": "AWS/ApiGateway",
+                "Dimensions": [
+                    {
+                        "Name": "APIName",
+                        "Value": {
+                            "Ref": "AWS::StackName"
+                        }
+                    }
+                ],
+                "ComparisonOperator": "GreaterThanThreshold",
+                "MetricName": "Count"
+            }
+        },
+        "gatewayTestRuleGatewayRuleResource": {
+            "Type": "AWS::ApiGateway::Resource",
+            "Properties": {
+                "ParentId": {
+                    "Fn::GetAtt": [
+                        "ApiGateway",
+                        "RootResourceId"
+                    ]
+                },
+                "RestApiId": {
+                    "Ref": "ApiGateway"
+                },
+                "PathPart": "gatewaytestrule"
+            }
+        },
+        "gatewayTestRuleGatewayRuleMethod": {
+            "Type": "AWS::ApiGateway::Method",
+            "Properties": {
+                "RestApiId": {
+                    "Ref": "ApiGateway"
+                },
+                "ResourceId": {
+                    "Ref": "gatewayTestRuleGatewayRuleResource"
+                },
+                "AuthorizationType": "None",
+                "HttpMethod": "POST",
+                "MethodResponses": [
+                    {
+                        "StatusCode": "200",
+                        "ResponseModels": {
+                            "application/json": "Empty"
+                        }
+                    },
+                    {
+                        "StatusCode": "500",
+                        "ResponseModels": {
+                            "application/json": "Empty"
+                        }
+                    }
+                ],
+                "Integration": {
+                    "Type": "AWS",
+                    "IntegrationHttpMethod": "POST",
+                    "IntegrationResponses": [
+                        {
+                            "StatusCode": "200"
+                        },
+                        {
+                            "StatusCode": "500",
+                            "SelectionPattern": ".*/Error|Exception/.*"
+                        }
+                    ],
+                    "Uri": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "arn:aws:apigateway:",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                ":lambda:path/2015-03-31/functions/",
+                                {
+                                    "Fn::GetAtt": [
+                                        "gatewayTestRule",
+                                        "Arn"
+                                    ]
+                                },
+                                "/invocations"
+                            ]
+                        ]
+                    }
+                },
+                "ApiKeyRequired": "true"
+            }
+        },
+        "gatewayTestRuleAlarmErrors": {
             "Type": "AWS::CloudWatch::Alarm",
             "Properties": {
                 "EvaluationPeriods": "5",
@@ -143,7 +329,7 @@
                     {
                         "Name": "FunctionName",
                         "Value": {
-                            "Ref": "full"
+                            "Ref": "gatewayTestRule"
                         }
                     }
                 ],
@@ -151,7 +337,7 @@
                 "MetricName": "Errors"
             }
         },
-        "fullAlarmNoInvocations": {
+        "gatewayTestRuleAlarmNoInvocations": {
             "Type": "AWS::CloudWatch::Alarm",
             "Properties": {
                 "EvaluationPeriods": "5",
@@ -169,7 +355,7 @@
                     {
                         "Name": "FunctionName",
                         "Value": {
-                            "Ref": "full"
+                            "Ref": "gatewayTestRule"
                         }
                     }
                 ],
@@ -257,20 +443,6 @@
                                 }
                             ]
                         }
-                    },
-                    {
-                        "PolicyName": "full",
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "s3:GetObject"
-                                    ],
-                                    "Resource": "arn:aws:s3:::mySuperDuperBucket"
-                                }
-                            ]
-                        }
                     }
                 ]
             }
@@ -293,5 +465,29 @@
         }
     },
     "Outputs": {
+        "APIKey": {
+            "Value": {
+                "Ref": "ApiKey"
+            }
+        },
+        "gatewayTestRuleAPIEndpoint": {
+            "Value": {
+                "Fn::Join": [
+                    "",
+                    [
+                        "https://",
+                        {
+                            "Ref": "ApiGateway"
+                        },
+                        ".execute-api.",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        ".amazonaws.com/prod/",
+                        "gatewaytestrule"
+                    ]
+                ]
+            }
+        }
     }
 }

--- a/test/fixtures/hybrid.template
+++ b/test/fixtures/hybrid.template
@@ -118,7 +118,7 @@
                 }
             }
         },
-        "hybridRuleeventRule": {
+        "hybridRuleEventRule": {
             "Type": "AWS::Events::Rule",
             "Properties": {
                 "EventPattern": {
@@ -268,6 +268,14 @@
                             "Effect": "Allow",
                             "Principal": {
                                 "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        },
+                        {
+                            "Sid": "",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "apigateway.amazonaws.com"
                             },
                             "Action": "sts:AssumeRole"
                         },

--- a/test/fixtures/scheduled.template
+++ b/test/fixtures/scheduled.template
@@ -223,6 +223,14 @@
                             "Sid": "",
                             "Effect": "Allow",
                             "Principal": {
+                                "Service": "apigateway.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        },
+                        {
+                            "Sid": "",
+                            "Effect": "Allow",
+                            "Principal": {
                                 "Service": "events.amazonaws.com"
                             },
                             "Action": "sts:AssumeRole"

--- a/test/fixtures/simple.template
+++ b/test/fixtures/simple.template
@@ -1,261 +1,269 @@
 {
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "LambdaCfn",
-  "Parameters": {
-    "CodeS3Bucket": {
-      "Type": "String",
-      "Description": "lambda function S3 bucket location"
-    },
-    "CodeS3Prefix": {
-      "Type": "String",
-      "Description": "lambda function S3 prefix location"
-    },
-    "GitSha": {
-      "Type": "String",
-      "Description": "lambda function S3 prefix location"
-    },
-    "StreambotEnv": {
-      "Type": "String",
-      "Description": "StreambotEnv lambda function ARN"
-    },
-    "AlarmEmail": {
-      "Type": "String",
-      "Description": "Alarm notifications will send to this email address"
-    }
-  },
-  "Resources": {
-    "simple": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "CodeS3Bucket"
-          },
-          "S3Key": {
-            "Fn::Join": [
-              "",
-              [
-                {
-                  "Ref": "CodeS3Prefix"
-                },
-                {
-                  "Ref": "GitSha"
-                },
-                ".zip"
-              ]
-            ]
-          }
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "LambdaCfn",
+    "Parameters": {
+        "CodeS3Bucket": {
+            "Type": "String",
+            "Description": "lambda function S3 bucket location"
         },
-        "Role": {
-          "Fn::GetAtt": [
-            "LambdaCfnRole",
-            "Arn"
-          ]
+        "CodeS3Prefix": {
+            "Type": "String",
+            "Description": "lambda function S3 prefix location"
         },
-        "Description": {
-          "Ref": "AWS::StackName"
+        "GitSha": {
+            "Type": "String",
+            "Description": "lambda function S3 prefix location"
         },
-        "Handler": "index.simple",
-        "MemorySize": 128,
-        "Runtime": "nodejs",
-        "Timeout": 60
-      },
-      "Metadata": {
-        "sourcePath": "rules/myRule.js"
-      }
-    },
-    "simplePermission": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "simple",
-            "Arn"
-          ]
+        "StreambotEnv": {
+            "Type": "String",
+            "Description": "StreambotEnv lambda function ARN"
         },
-        "Action": "lambda:InvokeFunction",
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::Join": [
-            "",
-            [
-              "arn:aws:events:",
-              {
-                "Ref": "AWS::Region"
-              },
-              ":",
-              {
-                "Ref": "AWS::AccountId"
-              },
-              ":rule/",
-              {
-                "Ref": "AWS::StackName"
-              },
-              "*"
-            ]
-          ]
+        "AlarmEmail": {
+            "Type": "String",
+            "Description": "Alarm notifications will send to this email address"
         }
-      }
     },
-    "StreambotEnvsimple": {
-      "Type": "Custom::StreambotEnv",
-      "Properties": {
-        "ServiceToken": {
-          "Ref": "StreambotEnv"
+    "Resources": {
+        "simple": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Code": {
+                    "S3Bucket": {
+                        "Ref": "CodeS3Bucket"
+                    },
+                    "S3Key": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                {
+                                    "Ref": "CodeS3Prefix"
+                                },
+                                {
+                                    "Ref": "GitSha"
+                                },
+                                ".zip"
+                            ]
+                        ]
+                    }
+                },
+                "Role": {
+                    "Fn::GetAtt": [
+                        "LambdaCfnRole",
+                        "Arn"
+                    ]
+                },
+                "Description": {
+                    "Ref": "AWS::StackName"
+                },
+                "Handler": "index.simple",
+                "Runtime": "nodejs",
+                "Timeout": 60,
+                "MemorySize": 128
+            },
+            "Metadata": {
+                "sourcePath": "rules/myRule.js"
+            }
         },
-        "FunctionName": {
-          "Ref": "simple"
+        "simplePermission": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "simple",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:aws:events:",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            ":",
+                            {
+                                "Ref": "AWS::AccountId"
+                            },
+                            ":rule/",
+                            {
+                                "Ref": "AWS::StackName"
+                            },
+                            "*"
+                        ]
+                    ]
+                }
+            }
+        },
+        "StreambotEnvsimple": {
+            "Type": "Custom::StreambotEnv",
+            "Properties": {
+                "ServiceToken": {
+                    "Ref": "StreambotEnv"
+                },
+                "FunctionName": {
+                    "Ref": "simple"
+                },
+                "LambdaCfnAlarmSNSTopic": {
+                    "Ref": "LambdaCfnAlarmSNSTopic"
+                }
+            }
+        },
+        "simpleAlarmErrors": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "EvaluationPeriods": "5",
+                "Statistic": "Sum",
+                "Threshold": "0",
+                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#Errors",
+                "Period": "60",
+                "AlarmActions": [
+                    {
+                        "Ref": "LambdaCfnAlarmSNSTopic"
+                    }
+                ],
+                "Namespace": "AWS/Lambda",
+                "Dimensions": [
+                    {
+                        "Name": "FunctionName",
+                        "Value": {
+                            "Ref": "simple"
+                        }
+                    }
+                ],
+                "ComparisonOperator": "GreaterThanThreshold",
+                "MetricName": "Errors"
+            }
+        },
+        "simpleAlarmNoInvocations": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "EvaluationPeriods": "5",
+                "Statistic": "Sum",
+                "Threshold": "0",
+                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#NoInvocations",
+                "Period": "60",
+                "AlarmActions": [
+                    {
+                        "Ref": "LambdaCfnAlarmSNSTopic"
+                    }
+                ],
+                "Namespace": "AWS/Lambda",
+                "Dimensions": [
+                    {
+                        "Name": "FunctionName",
+                        "Value": {
+                            "Ref": "simple"
+                        }
+                    }
+                ],
+                "ComparisonOperator": "LessThanThreshold",
+                "MetricName": "Invocations"
+            }
+        },
+        "LambdaCfnRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Sid": "",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "lambda.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        },
+                        {
+                            "Sid": "",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "apigateway.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        },
+                        {
+                            "Sid": "",
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": "events.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "basic",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "logs:*"
+                                    ],
+                                    "Resource": "arn:aws:logs:*:*:*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "dynamodb:GetItem"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:aws:dynamodb:us-east-1:",
+                                                {
+                                                    "Ref": "AWS::AccountId"
+                                                },
+                                                ":table/streambot-env*"
+                                            ]
+                                        ]
+                                    }
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "sns:Publish"
+                                    ],
+                                    "Resource": {
+                                        "Ref": "LambdaCfnAlarmSNSTopic"
+                                    }
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "iam:SimulateCustomPolicy"
+                                    ],
+                                    "Resource": "*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
         },
         "LambdaCfnAlarmSNSTopic": {
-          "Ref": "LambdaCfnAlarmSNSTopic"
-        }
-      }
-    },
-    "simpleAlarmErrors": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "EvaluationPeriods": "5",
-        "Statistic": "Sum",
-        "Threshold": "0",
-        "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#Errors",
-        "Period": "60",
-        "AlarmActions": [
-          {
-            "Ref": "LambdaCfnAlarmSNSTopic"
-          }
-        ],
-        "Namespace": "AWS/Lambda",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": {
-              "Ref": "simple"
-            }
-          }
-        ],
-        "ComparisonOperator": "GreaterThanThreshold",
-        "MetricName": "Errors"
-      }
-    },
-    "simpleAlarmNoInvocations": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "EvaluationPeriods": "5",
-        "Statistic": "Sum",
-        "Threshold": "0",
-        "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#NoInvocations",
-        "Period": "60",
-        "AlarmActions": [
-          {
-            "Ref": "LambdaCfnAlarmSNSTopic"
-          }
-        ],
-        "Namespace": "AWS/Lambda",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": {
-              "Ref": "simple"
-            }
-          }
-        ],
-        "ComparisonOperator": "LessThanThreshold",
-        "MetricName": "Invocations"
-      }
-    },
-    "LambdaCfnRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Sid": "",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com"
-              },
-              "Action": "sts:AssumeRole"
-            },
-            {
-              "Sid": "",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "events.amazonaws.com"
-              },
-              "Action": "sts:AssumeRole"
-            }
-          ]
-        },
-        "Path": "/",
-        "Policies": [
-          {
-            "PolicyName": "basic",
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "logs:*"
-                  ],
-                  "Resource": "arn:aws:logs:*:*:*"
+            "Type": "AWS::SNS::Topic",
+            "Properties": {
+                "TopicName": {
+                    "Ref": "AWS::StackName"
                 },
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "dynamodb:GetItem"
-                  ],
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:aws:dynamodb:us-east-1:",
-                        {
-                          "Ref": "AWS::AccountId"
+                "Subscription": [
+                    {
+                        "Endpoint": {
+                            "Ref": "AlarmEmail"
                         },
-                        ":table/streambot-env*"
-                      ]
-                    ]
-                  }
-                },
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "sns:Publish"
-                  ],
-                  "Resource": {
-                    "Ref": "LambdaCfnAlarmSNSTopic"
-                  }
-                },
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "iam:SimulateCustomPolicy"
-                  ],
-                  "Resource": "*"
-                }
-              ]
+                        "Protocol": "email"
+                    }
+                ]
             }
-          }
-        ]
-      }
+        }
     },
-    "LambdaCfnAlarmSNSTopic": {
-      "Type": "AWS::SNS::Topic",
-      "Properties": {
-        "TopicName": {
-          "Ref": "AWS::StackName"
-        },
-        "Subscription": [
-          {
-            "Endpoint": {
-              "Ref": "AlarmEmail"
-            },
-            "Protocol": "email"
-          }
-        ]
-      }
+    "Outputs": {
     }
-  },
-  "Outputs": {
-  }
 }

--- a/test/fixtures/sns.template
+++ b/test/fixtures/sns.template
@@ -267,6 +267,14 @@
                             "Sid": "",
                             "Effect": "Allow",
                             "Principal": {
+                                "Service": "apigateway.amazonaws.com"
+                            },
+                            "Action": "sts:AssumeRole"
+                        },
+                        {
+                            "Sid": "",
+                            "Effect": "Allow",
+                            "Principal": {
                                 "Service": "events.amazonaws.com"
                             },
                             "Action": "sts:AssumeRole"


### PR DESCRIPTION
@mick please take a gander when you've a chance. 

Broke:
- ~~Api deployment CFN support is broken, as CFN attempts to create the deployment immediately after the RestApi resource is created even though methods are required for a deployment. AWS support has confirmed this and filed a bug with the CFN team.~~ Lambda-cfn now creates an array of dependencies as a work around to force the API deployment to wait for all methods to be created.

Feedback:
- No request parameter support (don't know if this is a big deal or not)
- No model support

Random:
- The API alarms are place holders, I have no idea what the thresholds should be since they're undocumented and we don't have a whole lot of time on AG. I've filed an issue with AWS about the documenation.