### PR TITLE
Role statement

### DIFF
--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -1124,7 +1124,12 @@ function snsTopic(options) {
 }
 
 function splitOnComma (str) {
-  return str.split(/\s*,\s*/);
+  if (str) {
+    return str.split(/\s*,\s*/);
+  } else {
+    // splitting unset parameter shouldn't return a non-falsey value
+    return '';
+  }
 }
 
 function message(msg, callback) {
@@ -1150,9 +1155,9 @@ function message(msg, callback) {
 function getEnv(envVar) {
   for (var key in process.env) {
     if(key.indexOf(envVar) > -1) {
-      envVar = process.env[key];
-      break;
+      return process.env[key];
     }
   }
-  return envVar;
+  //mimic unset parameter if not found
+  return '';
 }

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -173,7 +173,9 @@ function compile(parts, template) {
     Description: 'Alarm notifications will send to this email address'
   };
 
+  var roleStub = role();
   var apiDeploymentDependsOn = [];
+
   parts.forEach(function(part) {
     // Parameters
     if (part.Parameters) {
@@ -218,11 +220,10 @@ function compile(parts, template) {
     }
 
     // Monolithic role
-    var roleStub = role();
-    if (part.Policy)
+    if (part.Policy) {
       roleStub.Properties.Policies.push(part.Policy);
+    }
     template.Resources.LambdaCfnRole = roleStub;
-
   });
 
   // Alarm SNS topic
@@ -231,7 +232,6 @@ function compile(parts, template) {
     template.Resources.ApiDeployment = apiDeployment(apiDeploymentDependsOn);
   }
   return template;
-
 }
 
 function parameters(options) {


### PR DESCRIPTION
This fixes building roles from statements defined within rules, as well as fixes non-falsey return values for falsey (typically unset) parameters in the splitOnComma and getEnv functions. 