### PR TITLE
better error mapping

### DIFF
--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -31,8 +31,6 @@ lambdaCfn.apiDeployment = apiDeployment;
 lambdaCfn.apiKey = apiKey;
 lambdaCfn.gatewayRules = gatewayRules;
 
-
-
 function stripPunc(r) {
   return r.replace(/[^A-Za-z0-9]/g,'');
 }
@@ -665,7 +663,7 @@ function gatewayRules(options,apiPart) {
         },
         {
           "StatusCode":"500",
-          "SelectionPattern": ".*/Error|Exception/.*"
+          "SelectionPattern": "^(?i)(error|exception).*"
         }
       ];
     }

--- a/test/fixtures/gateway.template
+++ b/test/fixtures/gateway.template
@@ -285,7 +285,7 @@
                         },
                         {
                             "StatusCode": "500",
-                            "SelectionPattern": ".*/Error|Exception/.*"
+                            "SelectionPattern": "^(?i)(error|exception).*"
                         }
                     ],
                     "Uri": {


### PR DESCRIPTION
Response mapping of lambda output to HTTP error code 500 now is case insensitive and anchored to line start. 