### PR TITLE
Random deployment name

### DIFF
--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -501,10 +501,7 @@ function apiDeployment(dependsOn) {
       "RestApiId": {
         "Ref": "ApiGateway"
       },
-      "StageName": "prod",
-      "StageDescription": {
-        "StageName": "prod"
-      }
+      "StageName": "prod"
     }
   };
   return apiDeploy;

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -226,8 +226,10 @@ function compile(parts, template) {
 
   // Alarm SNS topic
   template.Resources.LambdaCfnAlarmSNSTopic = snsTopic();
+
   if (template.Resources.ApiGateway) {
-    template.Resources.ApiDeployment = apiDeployment(apiDeploymentDependsOn);
+    var deployId = Math.random().toString(36).slice(2);
+    template.Resources['ApiDeployment-' + deployId] = apiDeployment(apiDeploymentDependsOn);
   }
   return template;
 }

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -5,6 +5,13 @@ var AWS = require('aws-sdk');
 var root = process.env.LAMBDA_TASK_ROOT ?
       process.env.LAMBDA_TASK_ROOT :
       require('app-root-path').path;
+var apiDeploymentRandom;
+
+if (process.env.NODE_ENV == 'test') {
+  apiDeploymentRandom = 'ApiDeployment';
+} else {
+  apiDeploymentRandom = 'ApiDeployment' + Math.random().toString(36).slice(2);
+}
 
 var lambdaCfn = module.exports = embed;
 module.exports.build = build;
@@ -228,8 +235,8 @@ function compile(parts, template) {
   template.Resources.LambdaCfnAlarmSNSTopic = snsTopic();
 
   if (template.Resources.ApiGateway) {
-    var deployId = Math.random().toString(36).slice(2);
-    template.Resources['ApiDeployment' + deployId] = apiDeployment(apiDeploymentDependsOn);
+
+    template.Resources[apiDeploymentRandom] = apiDeployment(apiDeploymentDependsOn);
   }
   return template;
 }
@@ -506,7 +513,7 @@ function apiDeployment(dependsOn) {
 function apiKey() {
   return {
     "Type": "AWS::ApiGateway::ApiKey",
-    "DependsOn": "ApiDeployment",
+    "DependsOn": apiDeploymentRandom,
     "Properties": {
       "Name": {
         "Ref": "AWS::StackName"

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -229,7 +229,7 @@ function compile(parts, template) {
 
   if (template.Resources.ApiGateway) {
     var deployId = Math.random().toString(36).slice(2);
-    template.Resources['ApiDeployment-' + deployId] = apiDeployment(apiDeploymentDependsOn);
+    template.Resources['ApiDeployment' + deployId] = apiDeployment(apiDeploymentDependsOn);
   }
   return template;
 }

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -192,18 +192,7 @@ tape('Compile ApiGateway based rule', function(t) {
 
   var gatewayBuilt = lambdaCfn.compile([lambdaCfn.build(gatewayConfig)], {});
   var gatewayFixture = JSON.parse(fs.readFileSync(path.join(__dirname,'./fixtures/gateway.template'),"utf8"));
-  for (var output in gatewayBuilt.Outputs) {
-    t.deepLooseEqual(gatewayBuilt.Outputs[output],gatewayFixture.Outputs[output]);
-  }
-  for (var param in gatewayBuilt.Parameters) {
-    t.deepLooseEqual(gatewayBuilt.Parameters[param],gatewayFixture.Parameters[param]);
-  }
-  for (var resource in gatewayBuilt.Resources) {
-    if (resource.match(/ApiDeployment/)) {
-      t.deepLooseEqual(gatewayBuilt.Resources[resource],gatewayFixture.Resources.ApiDeployment);
-    } else {
-      t.deepLooseEqual(gatewayBuilt.Resources[resource],gatewayFixture.Resources[resource]);
-    }
-  }
+
+  t.deepLooseEqual(gatewayBuilt,gatewayFixture, 'Gateway rule build is equal to fixture');
   t.end();
 });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -192,7 +192,18 @@ tape('Compile ApiGateway based rule', function(t) {
 
   var gatewayBuilt = lambdaCfn.compile([lambdaCfn.build(gatewayConfig)], {});
   var gatewayFixture = JSON.parse(fs.readFileSync(path.join(__dirname,'./fixtures/gateway.template'),"utf8"));
-
-  t.deepLooseEqual(gatewayBuilt,gatewayFixture, 'Gateway rule build is equal to fixture');
+  for (var output in gatewayBuilt.Outputs) {
+    t.deepLooseEqual(gatewayBuilt.Outputs[output],gatewayFixture.Outputs[output]);
+  }
+  for (var param in gatewayBuilt.Parameters) {
+    t.deepLooseEqual(gatewayBuilt.Parameters[param],gatewayFixture.Parameters[param]);
+  }
+  for (var resource in gatewayBuilt.Resources) {
+    if (resource.match(/ApiDeployment/)) {
+      t.deepLooseEqual(gatewayBuilt.Resources[resource],gatewayFixture.Resources.ApiDeployment);
+    } else {
+      t.deepLooseEqual(gatewayBuilt.Resources[resource],gatewayFixture.Resources[resource]);
+    }
+  }
   t.end();
 });

--- a/test/fixtures/gateway.template
+++ b/test/fixtures/gateway.template
@@ -1,493 +1,492 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "LambdaCfn",
-    "Parameters": {
-        "CodeS3Bucket": {
-            "Type": "String",
-            "Description": "lambda function S3 bucket location"
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "LambdaCfn",
+  "Parameters": {
+    "CodeS3Bucket": {
+      "Type": "String",
+      "Description": "lambda function S3 bucket location"
+    },
+    "CodeS3Prefix": {
+      "Type": "String",
+      "Description": "lambda function S3 prefix location"
+    },
+    "GitSha": {
+      "Type": "String",
+      "Description": "lambda function S3 prefix location"
+    },
+    "StreambotEnv": {
+      "Type": "String",
+      "Description": "StreambotEnv lambda function ARN"
+    },
+    "AlarmEmail": {
+      "Type": "String",
+      "Description": "Alarm notifications will send to this email address"
+    },
+    "gatewayTestRuletoken": {
+      "Type": "String",
+      "Description": "token"
+    }
+  },
+  "Resources": {
+    "gatewayTestRule": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "CodeS3Bucket"
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Ref": "CodeS3Prefix"
+                },
+                {
+                  "Ref": "GitSha"
+                },
+                ".zip"
+              ]
+            ]
+          }
         },
-        "CodeS3Prefix": {
-            "Type": "String",
-            "Description": "lambda function S3 prefix location"
+        "Role": {
+          "Fn::GetAtt": [
+            "LambdaCfnRole",
+            "Arn"
+          ]
         },
-        "GitSha": {
-            "Type": "String",
-            "Description": "lambda function S3 prefix location"
+        "Description": {
+          "Ref": "AWS::StackName"
         },
-        "StreambotEnv": {
-            "Type": "String",
-            "Description": "StreambotEnv lambda function ARN"
+        "Handler": "index.gatewayTestRule",
+        "Runtime": "nodejs",
+        "Timeout": 60,
+        "MemorySize": 128
+      },
+      "Metadata": {
+        "sourcePath": "test/rules/gatewayTestRule.js"
+      }
+    },
+    "gatewayTestRulePermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "gatewayTestRule",
+            "Arn"
+          ]
         },
-        "AlarmEmail": {
-            "Type": "String",
-            "Description": "Alarm notifications will send to this email address"
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGateway"
+              },
+              "/*"
+            ]
+          ]
+        }
+      }
+    },
+    "StreambotEnvgatewayTestRule": {
+      "Type": "Custom::StreambotEnv",
+      "Properties": {
+        "ServiceToken": {
+          "Ref": "StreambotEnv"
+        },
+        "FunctionName": {
+          "Ref": "gatewayTestRule"
         },
         "gatewayTestRuletoken": {
-            "Type": "String",
-            "Description": "token"
-        }
-    },
-    "Resources": {
-        "gatewayTestRule": {
-            "Type": "AWS::Lambda::Function",
-            "Properties": {
-                "Code": {
-                    "S3Bucket": {
-                        "Ref": "CodeS3Bucket"
-                    },
-                    "S3Key": {
-                        "Fn::Join": [
-                            "",
-                            [
-                                {
-                                    "Ref": "CodeS3Prefix"
-                                },
-                                {
-                                    "Ref": "GitSha"
-                                },
-                                ".zip"
-                            ]
-                        ]
-                    }
-                },
-                "Role": {
-                    "Fn::GetAtt": [
-                        "LambdaCfnRole",
-                        "Arn"
-                    ]
-                },
-                "Description": {
-                    "Ref": "AWS::StackName"
-                },
-                "Handler": "index.gatewayTestRule",
-                "Runtime": "nodejs",
-                "Timeout": 60,
-                "MemorySize": 128
-            },
-            "Metadata": {
-                "sourcePath": "test/rules/gatewayTestRule.js"
-            }
-        },
-        "gatewayTestRulePermission": {
-            "Type": "AWS::Lambda::Permission",
-            "Properties": {
-                "FunctionName": {
-                    "Fn::GetAtt": [
-                        "gatewayTestRule",
-                        "Arn"
-                    ]
-                },
-                "Action": "lambda:InvokeFunction",
-                "Principal": "apigateway.amazonaws.com",
-                "SourceArn": {
-                    "Fn::Join": [
-                        "",
-                        [
-                            "arn:aws:execute-api:",
-                            {
-                                "Ref": "AWS::Region"
-                            },
-                            ":",
-                            {
-                                "Ref": "AWS::AccountId"
-                            },
-                            ":",
-                            {
-                                "Ref": "ApiGateway"
-                            },
-                            "/*"
-                        ]
-                    ]
-                }
-            }
-        },
-        "StreambotEnvgatewayTestRule": {
-            "Type": "Custom::StreambotEnv",
-            "Properties": {
-                "ServiceToken": {
-                    "Ref": "StreambotEnv"
-                },
-                "FunctionName": {
-                    "Ref": "gatewayTestRule"
-                },
-                "gatewayTestRuletoken": {
-                    "Ref": "gatewayTestRuletoken"
-                },
-                "LambdaCfnAlarmSNSTopic": {
-                    "Ref": "LambdaCfnAlarmSNSTopic"
-                }
-            }
-        },
-        "ApiGateway": {
-            "Type": "AWS::ApiGateway::RestApi",
-            "Properties": {
-                "Name": {
-                    "Ref": "AWS::StackName"
-                },
-                "FailOnWarnings": "true"
-            }
-        },
-        "ApiKey": {
-            "Type": "AWS::ApiGateway::ApiKey",
-            "DependsOn": "ApiDeployment",
-            "Properties": {
-                "Name": {
-                    "Ref": "AWS::StackName"
-                },
-                "Enabled": "true",
-                "StageKeys": [
-                    {
-                        "RestApiId": {
-                            "Ref": "ApiGateway"
-                        },
-                        "StageName": "prod"
-                    }
-                ]
-            }
-        },
-        "ApiDeployment": {
-            "Type": "AWS::ApiGateway::Deployment",
-            "DependsOn": [ "gatewayTestRuleGatewayRuleMethod" ],
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ApiGateway"
-                },
-                "StageName": "prod",
-                "StageDescription": {
-                    "StageName": "prod"
-                }
-            }
-        },
-        "ApiLatencyAlarm": {
-            "Type": "AWS::CloudWatch::Alarm",
-            "Properties": {
-                "EvaluationPeriods": "5",
-                "Statistic": "Sum",
-                "Threshold": "4",
-                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#ApiLatencyAlarm",
-                "Period": "60",
-                "AlarmActions": [
-                    {
-                        "Ref": "LambdaCfnAlarmSNSTopic"
-                    }
-                ],
-                "Namespace": "AWS/ApiGateway",
-                "Dimensions": [
-                    {
-                        "Name": "APIName",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }
-                ],
-                "ComparisonOperator": "GreaterThanThreshold",
-                "MetricName": "Latency"
-            }
-        },
-        "Api4xxAlarm": {
-            "Type": "AWS::CloudWatch::Alarm",
-            "Properties": {
-                "EvaluationPeriods": "5",
-                "Statistic": "Sum",
-                "Threshold": "100",
-                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#Api4xxAlarm",
-                "Period": "60",
-                "AlarmActions": [
-                    {
-                        "Ref": "LambdaCfnAlarmSNSTopic"
-                    }
-                ],
-                "Namespace": "AWS/ApiGateway",
-                "Dimensions": [
-                    {
-                        "Name": "APIName",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }
-                ],
-                "ComparisonOperator": "GreaterThanThreshold",
-                "MetricName": "4xxError"
-            }
-        },
-        "ApiCountAlarm": {
-            "Type": "AWS::CloudWatch::Alarm",
-            "Properties": {
-                "EvaluationPeriods": "5",
-                "Statistic": "Sum",
-                "Threshold": "10000",
-                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#ApiCountAlarm",
-                "Period": "60",
-                "AlarmActions": [
-                    {
-                        "Ref": "LambdaCfnAlarmSNSTopic"
-                    }
-                ],
-                "Namespace": "AWS/ApiGateway",
-                "Dimensions": [
-                    {
-                        "Name": "APIName",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    }
-                ],
-                "ComparisonOperator": "GreaterThanThreshold",
-                "MetricName": "Count"
-            }
-        },
-        "gatewayTestRuleGatewayRuleResource": {
-            "Type": "AWS::ApiGateway::Resource",
-            "Properties": {
-                "ParentId": {
-                    "Fn::GetAtt": [
-                        "ApiGateway",
-                        "RootResourceId"
-                    ]
-                },
-                "RestApiId": {
-                    "Ref": "ApiGateway"
-                },
-                "PathPart": "gatewaytestrule"
-            }
-        },
-        "gatewayTestRuleGatewayRuleMethod": {
-            "Type": "AWS::ApiGateway::Method",
-            "Properties": {
-                "RestApiId": {
-                    "Ref": "ApiGateway"
-                },
-                "ResourceId": {
-                    "Ref": "gatewayTestRuleGatewayRuleResource"
-                },
-                "AuthorizationType": "None",
-                "HttpMethod": "POST",
-                "MethodResponses": [
-                    {
-                        "StatusCode": "200",
-                        "ResponseModels": {
-                            "application/json": "Empty"
-                        }
-                    },
-                    {
-                        "StatusCode": "500",
-                        "ResponseModels": {
-                            "application/json": "Empty"
-                        }
-                    }
-                ],
-                "Integration": {
-                    "Type": "AWS",
-                    "IntegrationHttpMethod": "POST",
-                    "IntegrationResponses": [
-                        {
-                            "StatusCode": "200"
-                        },
-                        {
-                            "StatusCode": "500",
-                            "SelectionPattern": "^(?i)(error|exception).*"
-                        }
-                    ],
-                    "Uri": {
-                        "Fn::Join": [
-                            "",
-                            [
-                                "arn:aws:apigateway:",
-                                {
-                                    "Ref": "AWS::Region"
-                                },
-                                ":lambda:path/2015-03-31/functions/",
-                                {
-                                    "Fn::GetAtt": [
-                                        "gatewayTestRule",
-                                        "Arn"
-                                    ]
-                                },
-                                "/invocations"
-                            ]
-                        ]
-                    }
-                },
-                "ApiKeyRequired": "true"
-            }
-        },
-        "gatewayTestRuleAlarmErrors": {
-            "Type": "AWS::CloudWatch::Alarm",
-            "Properties": {
-                "EvaluationPeriods": "5",
-                "Statistic": "Sum",
-                "Threshold": "0",
-                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#Errors",
-                "Period": "60",
-                "AlarmActions": [
-                    {
-                        "Ref": "LambdaCfnAlarmSNSTopic"
-                    }
-                ],
-                "Namespace": "AWS/Lambda",
-                "Dimensions": [
-                    {
-                        "Name": "FunctionName",
-                        "Value": {
-                            "Ref": "gatewayTestRule"
-                        }
-                    }
-                ],
-                "ComparisonOperator": "GreaterThanThreshold",
-                "MetricName": "Errors"
-            }
-        },
-        "gatewayTestRuleAlarmNoInvocations": {
-            "Type": "AWS::CloudWatch::Alarm",
-            "Properties": {
-                "EvaluationPeriods": "5",
-                "Statistic": "Sum",
-                "Threshold": "0",
-                "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#NoInvocations",
-                "Period": "60",
-                "AlarmActions": [
-                    {
-                        "Ref": "LambdaCfnAlarmSNSTopic"
-                    }
-                ],
-                "Namespace": "AWS/Lambda",
-                "Dimensions": [
-                    {
-                        "Name": "FunctionName",
-                        "Value": {
-                            "Ref": "gatewayTestRule"
-                        }
-                    }
-                ],
-                "ComparisonOperator": "LessThanThreshold",
-                "MetricName": "Invocations"
-            }
-        },
-        "LambdaCfnRole": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "AssumeRolePolicyDocument": {
-                    "Statement": [
-                        {
-                            "Sid": "",
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": "lambda.amazonaws.com"
-                            },
-                            "Action": "sts:AssumeRole"
-                        },
-                        {
-                            "Sid": "",
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": "apigateway.amazonaws.com"
-                            },
-                            "Action": "sts:AssumeRole"
-                        },
-                        {
-                            "Sid": "",
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": "events.amazonaws.com"
-                            },
-                            "Action": "sts:AssumeRole"
-                        }
-                    ]
-                },
-                "Path": "/",
-                "Policies": [
-                    {
-                        "PolicyName": "basic",
-                        "PolicyDocument": {
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "logs:*"
-                                    ],
-                                    "Resource": "arn:aws:logs:*:*:*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "dynamodb:GetItem"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Join": [
-                                            "",
-                                            [
-                                                "arn:aws:dynamodb:us-east-1:",
-                                                {
-                                                    "Ref": "AWS::AccountId"
-                                                },
-                                                ":table/streambot-env*"
-                                            ]
-                                        ]
-                                    }
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "sns:Publish"
-                                    ],
-                                    "Resource": {
-                                        "Ref": "LambdaCfnAlarmSNSTopic"
-                                    }
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "iam:SimulateCustomPolicy"
-                                    ],
-                                    "Resource": "*"
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
+          "Ref": "gatewayTestRuletoken"
         },
         "LambdaCfnAlarmSNSTopic": {
-            "Type": "AWS::SNS::Topic",
-            "Properties": {
-                "TopicName": {
-                    "Ref": "AWS::StackName"
-                },
-                "Subscription": [
-                    {
-                        "Endpoint": {
-                            "Ref": "AlarmEmail"
-                        },
-                        "Protocol": "email"
-                    }
-                ]
-            }
+          "Ref": "LambdaCfnAlarmSNSTopic"
         }
+      }
     },
-    "Outputs": {
-        "APIKey": {
-            "Value": {
-                "Ref": "ApiKey"
-            }
+    "ApiGateway": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": {
+          "Ref": "AWS::StackName"
         },
-        "gatewayTestRuleAPIEndpoint": {
+        "FailOnWarnings": "true"
+      }
+    },
+    "ApiKey": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "DependsOn": "ApiDeployment",
+      "Properties": {
+        "Name": {
+          "Ref": "AWS::StackName"
+        },
+        "Enabled": "true",
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "ApiGateway"
+            },
+            "StageName": "prod"
+          }
+        ]
+      }
+    },
+    "ApiDeployment": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "DependsOn": [
+        "gatewayTestRuleGatewayRuleMethod"
+      ],
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiGateway"
+        },
+        "StageName": "prod"
+      }
+    },
+    "ApiLatencyAlarm": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "EvaluationPeriods": "5",
+        "Statistic": "Sum",
+        "Threshold": "4",
+        "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#ApiLatencyAlarm",
+        "Period": "60",
+        "AlarmActions": [
+          {
+            "Ref": "LambdaCfnAlarmSNSTopic"
+          }
+        ],
+        "Namespace": "AWS/ApiGateway",
+        "Dimensions": [
+          {
+            "Name": "APIName",
             "Value": {
-                "Fn::Join": [
-                    "",
-                    [
-                        "https://",
-                        {
-                            "Ref": "ApiGateway"
-                        },
-                        ".execute-api.",
-                        {
-                            "Ref": "AWS::Region"
-                        },
-                        ".amazonaws.com/prod/",
-                        "gatewaytestrule"
-                    ]
-                ]
+              "Ref": "AWS::StackName"
             }
-        }
+          }
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "MetricName": "Latency"
+      }
+    },
+    "Api4xxAlarm": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "EvaluationPeriods": "5",
+        "Statistic": "Sum",
+        "Threshold": "100",
+        "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#Api4xxAlarm",
+        "Period": "60",
+        "AlarmActions": [
+          {
+            "Ref": "LambdaCfnAlarmSNSTopic"
+          }
+        ],
+        "Namespace": "AWS/ApiGateway",
+        "Dimensions": [
+          {
+            "Name": "APIName",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "MetricName": "4xxError"
+      }
+    },
+    "ApiCountAlarm": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "EvaluationPeriods": "5",
+        "Statistic": "Sum",
+        "Threshold": "10000",
+        "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#ApiCountAlarm",
+        "Period": "60",
+        "AlarmActions": [
+          {
+            "Ref": "LambdaCfnAlarmSNSTopic"
+          }
+        ],
+        "Namespace": "AWS/ApiGateway",
+        "Dimensions": [
+          {
+            "Name": "APIName",
+            "Value": {
+              "Ref": "AWS::StackName"
+            }
+          }
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "MetricName": "Count"
+      }
+    },
+    "gatewayTestRuleGatewayRuleResource": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGateway",
+            "RootResourceId"
+          ]
+        },
+        "RestApiId": {
+          "Ref": "ApiGateway"
+        },
+        "PathPart": "gatewaytestrule"
+      }
+    },
+    "gatewayTestRuleGatewayRuleMethod": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiGateway"
+        },
+        "ResourceId": {
+          "Ref": "gatewayTestRuleGatewayRuleResource"
+        },
+        "AuthorizationType": "None",
+        "HttpMethod": "POST",
+        "MethodResponses": [
+          {
+            "StatusCode": "200",
+            "ResponseModels": {
+              "application/json": "Empty"
+            }
+          },
+          {
+            "StatusCode": "500",
+            "ResponseModels": {
+              "application/json": "Empty"
+            }
+          }
+        ],
+        "Integration": {
+          "Type": "AWS",
+          "IntegrationHttpMethod": "POST",
+          "IntegrationResponses": [
+            {
+              "StatusCode": "200"
+            },
+            {
+              "StatusCode": "500",
+              "SelectionPattern": "^(?i)(error|exception).*"
+            }
+          ],
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "gatewayTestRule",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "ApiKeyRequired": "true"
+      }
+    },
+    "gatewayTestRuleAlarmErrors": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "EvaluationPeriods": "5",
+        "Statistic": "Sum",
+        "Threshold": "0",
+        "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#Errors",
+        "Period": "60",
+        "AlarmActions": [
+          {
+            "Ref": "LambdaCfnAlarmSNSTopic"
+          }
+        ],
+        "Namespace": "AWS/Lambda",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "gatewayTestRule"
+            }
+          }
+        ],
+        "ComparisonOperator": "GreaterThanThreshold",
+        "MetricName": "Errors"
+      }
+    },
+    "gatewayTestRuleAlarmNoInvocations": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "EvaluationPeriods": "5",
+        "Statistic": "Sum",
+        "Threshold": "0",
+        "AlarmDescription": "https://github.com/mapbox/lambda-cfn/blob/master/alarms.md#NoInvocations",
+        "Period": "60",
+        "AlarmActions": [
+          {
+            "Ref": "LambdaCfnAlarmSNSTopic"
+          }
+        ],
+        "Namespace": "AWS/Lambda",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "gatewayTestRule"
+            }
+          }
+        ],
+        "ComparisonOperator": "LessThanThreshold",
+        "MetricName": "Invocations"
+      }
+    },
+    "LambdaCfnRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Sid": "",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              },
+              "Action": "sts:AssumeRole"
+            },
+            {
+              "Sid": "",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com"
+              },
+              "Action": "sts:AssumeRole"
+            },
+            {
+              "Sid": "",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com"
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "basic",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:*"
+                  ],
+                  "Resource": "arn:aws:logs:*:*:*"
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "dynamodb:GetItem"
+                  ],
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:aws:dynamodb:us-east-1:",
+                        {
+                          "Ref": "AWS::AccountId"
+                        },
+                        ":table/streambot-env*"
+                      ]
+                    ]
+                  }
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "sns:Publish"
+                  ],
+                  "Resource": {
+                    "Ref": "LambdaCfnAlarmSNSTopic"
+                  }
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "iam:SimulateCustomPolicy"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "LambdaCfnAlarmSNSTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "TopicName": {
+          "Ref": "AWS::StackName"
+        },
+        "Subscription": [
+          {
+            "Endpoint": {
+              "Ref": "AlarmEmail"
+            },
+            "Protocol": "email"
+          }
+        ]
+      }
     }
+  },
+  "Outputs": {
+    "APIKey": {
+      "Value": {
+        "Ref": "ApiKey"
+      }
+    },
+    "gatewayTestRuleAPIEndpoint": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "ApiGateway"
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region"
+            },
+            ".amazonaws.com/prod/",
+            "gatewaytestrule"
+          ]
+        ]
+      }
+    }
+  }
 }


### PR DESCRIPTION
This is a workaround for a quirk in CFN's support for API-GW. Deployments are immutable, so we get around this by creating a random name for the deployment so that it creates a new deployment every time. If this isn't done, then an update to an APi-GW rule will not be live until someone goes into the console and redeploys the API. 