### PR TITLE
Configurable node.js runtime environment + Node 4.3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 sudo: false
 node_js:
-- 0.10.38
+- 0.10.36
 - 4.3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 sudo: false
 node_js:
 - 0.10.38
+- 4.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. For change 
 ## Unreleased
 - none
 
+## 0.1.5 2016-12-9
+- Enabled Node 4.3.2 runtime support
+- Allows for configurable runtime - `nodejs` or `nodejs4.3`
+
 ## 0.1.4 2016-06-06
 - Randomized API deployment name so methods are redeployed on every update.
 

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -381,6 +381,12 @@ function lambda(options) {
     fn.Properties.MemorySize = 128;
   }
 
+  if (options.runtime) {
+    if (!(options.runtime !== 'nodejs' || options.runtime !== 'nodejs4.3')) {
+      throw new Error('Invalid AWS Lambda node.js runtime ' + options.runtime);
+    }
+  }
+
   return fn;
 
 }

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -385,7 +385,11 @@ function lambda(options) {
     var validRuntimes = ['nodejs','nodejs4.3'];
     if (validRuntimes.indexOf(options.runtime) === -1 ) {
       throw new Error('Invalid AWS Lambda node.js runtime ' + options.runtime);
+    } else {
+      fn.Properties.Runtime = options.runtime;
     }
+  } else {
+    fn.Properties.Runtime = 'nodejs4.3';
   }
 
   return fn;

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -382,7 +382,8 @@ function lambda(options) {
   }
 
   if (options.runtime) {
-    if (!(options.runtime !== 'nodejs' || options.runtime !== 'nodejs4.3')) {
+    var validRuntimes = ['nodejs','nodejs4.3'];
+    if (validRuntimes.indexOf(options.runtime) === -1 ) {
       throw new Error('Invalid AWS Lambda node.js runtime ' + options.runtime);
     }
   }

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -350,7 +350,7 @@ function lambda(options) {
         "Ref": "AWS::StackName"
       },
       "Handler": "index." + options.name,
-      "Runtime": "nodejs"
+      "Runtime": options.runtime
     },
     "Metadata": {
       "sourcePath": options.sourcePath

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "lambda-cfn",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CloudFormation boiler plate for lambda functions",
   "main": "lib/lambda-cfn.js",
   "engines": {
-    "node": "0.10.38"
+    "node": "0.10.36 || 4.3.2"
   },
   "repository": {
     "type": "git",

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -71,8 +71,6 @@ tape('Compile SNS rule', function(t) {
   var snsBuilt = lambdaCfn.compile([lambdaCfn.build(snsConfig)], {});
   var snsFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/sns.template'), "utf8"));
 
-  console.log(snsBuilt);
-
   t.deepEqual(snsBuilt,snsFixture, 'SNS rule build is equal to fixture');
 
   t.end();

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -12,6 +12,7 @@ tape('Compile unit tests', function(t) {
 
   var simpleBuilt = lambdaCfn.compile([lambdaCfn.build({
     name: 'simple',
+    runtime: 'nodejs4.3',
     sourcePath: 'rules/myRule.js'
   })], {});
 
@@ -21,6 +22,7 @@ tape('Compile unit tests', function(t) {
 
   var fullConfig = {
     name: 'full',
+    runtime: 'nodejs4.3',
     sourcePath: 'rules/myRule.js',
     parameters: {
       'githubToken': {
@@ -55,6 +57,7 @@ tape('Compile unit tests', function(t) {
 tape('Compile SNS rule', function(t) {
   var snsConfig = {
     name: 'sns',
+    runtime: 'nodejs',
     sourcePath: 'rules/sns.js',
     parameters: {
       'token': {
@@ -68,6 +71,8 @@ tape('Compile SNS rule', function(t) {
   var snsBuilt = lambdaCfn.compile([lambdaCfn.build(snsConfig)], {});
   var snsFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/sns.template'), "utf8"));
 
+  console.log(snsBuilt);
+
   t.deepEqual(snsBuilt,snsFixture, 'SNS rule build is equal to fixture');
 
   t.end();
@@ -77,6 +82,7 @@ tape('Compile SNS rule', function(t) {
 tape('Compile Event rule', function(t) {
   var eventConfig = {
     name: 'eventRule',
+    runtime: 'nodejs4.3',
     sourcePath: 'rules/eventRule.js',
     parameters: {
       'token': {
@@ -116,6 +122,7 @@ tape('Compile Event rule', function(t) {
 tape('Compile Scheduled rule', function(t) {
   var scheduledConfig = {
     name: 'scheduledRule',
+    runtime: 'nodejs',
     sourcePath: 'rules/scheduledRule.js',
     parameters: {
       'token': {
@@ -138,6 +145,7 @@ tape('Compile Scheduled rule', function(t) {
 tape('Compile Hybrid Scheduled and Hybrid based rule', function(t) {
   var hybridConfig = {
     name: 'hybridRule',
+    runtime: 'nodejs4.3',
     sourcePath: 'rules/hybridRule.js',
     parameters: {
       'token': {
@@ -177,6 +185,7 @@ tape('Compile Hybrid Scheduled and Hybrid based rule', function(t) {
 tape('Compile ApiGateway based rule', function(t) {
   var gatewayConfig = {
     name: 'gatewayTestRule',
+    runtime: 'nodejs',
     sourcePath: 'test/rules/gatewayTestRule.js',
     parameters: {
       'token': {

--- a/test/fixtures/event.template
+++ b/test/fixtures/event.template
@@ -60,7 +60,7 @@
                     "Ref": "AWS::StackName"
                 },
                 "Handler": "index.eventRule",
-                "Runtime": "nodejs",
+                "Runtime": "nodejs4.3",
                 "Timeout": 60,
                 "MemorySize": 128
             },

--- a/test/fixtures/full.template
+++ b/test/fixtures/full.template
@@ -64,7 +64,7 @@
                     "Ref": "AWS::StackName"
                 },
                 "Handler": "index.full",
-                "Runtime": "nodejs",
+                "Runtime": "nodejs4.3",
                 "Timeout": 60,
                 "MemorySize": 128
             },

--- a/test/fixtures/hybrid.template
+++ b/test/fixtures/hybrid.template
@@ -60,7 +60,7 @@
                     "Ref": "AWS::StackName"
                 },
                 "Handler": "index.hybridRule",
-                "Runtime": "nodejs",
+                "Runtime": "nodejs4.3",
                 "Timeout": 60,
                 "MemorySize": 128
             },

--- a/test/fixtures/simple.template
+++ b/test/fixtures/simple.template
@@ -56,7 +56,7 @@
                     "Ref": "AWS::StackName"
                 },
                 "Handler": "index.simple",
-                "Runtime": "nodejs",
+                "Runtime": "nodejs4.3",
                 "Timeout": 60,
                 "MemorySize": 128
             },

--- a/test/lambda-cfn.test.js
+++ b/test/lambda-cfn.test.js
@@ -67,6 +67,8 @@ tape('lambda unit tests', function(t) {
   t.equal(def.Properties.Runtime, 'nodejs', 'Created Node 0.10 runtime Lambda');
   def = lambda({name: 'myHandler', runtime: 'nodejs4.3'});
   t.equal(def.Properties.Runtime, 'nodejs4.3', 'Created Node 4.3.2 runtime Lambda');
+  def = lambda({name: 'myHandler'});
+  t.equal(def.Properties.Runtime, 'nodejs4.3', 'Default to Node 4.3.2 runtime if not specified');
 
   t.throws(
     function() {

--- a/test/lambda-cfn.test.js
+++ b/test/lambda-cfn.test.js
@@ -68,6 +68,12 @@ tape('lambda unit tests', function(t) {
   def = lambda({name: 'myHandler', runtime: 'nodejs4.3'});
   t.equal(def.Properties.Runtime, 'nodejs4.3', 'Created Node 4.3.2 runtime Lambda');
 
+  t.throws(
+    function() {
+      lambda({name: 'myHandler', runtime: 'foobarbaz'});
+    }, /Invalid AWS Lambda node.js runtime foobarbaz/, 'Fails with invalid runtime'
+  );
+
   t.end();
 
 });

--- a/test/lambda-cfn.test.js
+++ b/test/lambda-cfn.test.js
@@ -63,6 +63,10 @@ tape('lambda unit tests', function(t) {
   t.equal(def.Properties.Timeout, 60, 'Lambda timeout safe default');
   def = lambda({name: 'myHandler', memorySize: 1111, timeout: 600});
   t.equal(def.Properties.MemorySize, 128, 'Lambda memory size mod 64 safe default');
+  def = lambda({name: 'myHandler', runtime: 'nodejs'});
+  t.equal(def.Properties.Runtime, 'nodejs', 'Created Node 0.10 runtime Lambda');
+  def = lambda({name: 'myHandler', runtime: 'nodejs4.3'});
+  t.equal(def.Properties.Runtime, 'nodejs4.3', 'Created Node 4.3.2 runtime Lambda');
 
   t.end();
 

--- a/test/rules/assumeRole.js
+++ b/test/rules/assumeRole.js
@@ -4,6 +4,7 @@ var splitOnComma = require('../../').splitOnComma;
 module.exports.config = {
   name: 'assumeRole',
   sourcePath: 'rules/assumeRole.js',
+  runtime: 'nodejs',
   parameters: {
     'blacklistedRoles': {
       'Type': 'String',

--- a/test/rules/getEnvTest.js
+++ b/test/rules/getEnvTest.js
@@ -5,6 +5,7 @@ var getEnv = require(process.cwd()).getEnv;
 module.exports.config = {
   name: 'getEnvTest',
   sourcePath: 'rules/getEnvTest.js',
+  runtime: 'nodejs4.3',
   parameters: {
     'testParameter1': {
       'Type': 'String',


### PR DESCRIPTION
Per discussion in https://github.com/mapbox/lambda-cfn/issues/27#issuecomment-265822498, makes it possible for a user to configure the Node.js runtime environment via `module.exports.config`, rather than hard code this value to `nodejs` or `nodejs4.3`.

Example usage:

```js
module.exports.config = {
    name: 'myLambdaFunction',
    runtime: 'nodejs4.3',
    sourcePath: 'lib/myLambdaFunction.js',
    timeout: 300,
    <rest of code here>
}
```

/cc @ianshward @zmully 