### PR TITLE
Lambda Native Environment Variables and Removal of Streambot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. For change 
 ## Unreleased
 - none
 
+## 1.0.0 2016-12-09 
+- Removed all dependencies on  [streambot](https://github.com/mapbox/streambot)
+- Enabled native environment variables in Lambda
+- Functions given to Lambda-cfn should now use the official [AWS Lambda Programming Model](http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html) for their selected version of Node.
+
 ## 0.1.5 2016-12-9
 - Enabled Node 4.3.2 runtime support
 - Allows for configurable runtime - `nodejs` or `nodejs4.3`

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ module.exports = lambdaCfn(
 
 where in `myHandler.js` you've exported:
 
-- module.exports.fn - a function which is wrapped by [streambot](git@github.com:mapbox/streambot.git) and which will get called by Lambda.  Steambot is used for [runtime configuration](https://github.com/mapbox/streambot#runtime-configuration) which is able to be defined in module.exports.config
-- module.exports.config - allows you to define some configuration for your Lambda function.  See the [rules spec](RULE-SPEC.md) for all options.
+- module.exports.fn - a function which takes in event, context, callback and which will get called by Lambda. See [lambda documentation](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html) for help on using context or the callback.
+- module.exports.config - allows you to define some configuration for your Lambda function.  See the [rules spec](https://github.com/mapbox/lambda-cfn/blob/readme/RULE-SPEC.md) for all options.
 
 After uploading a zip of your project to a location in Lambda, you can then deploy this javascript CloudFormation template with [cfn-config](https://github.com/mapbox/cfn-config#usage-1) to deploy your function.
 

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -1,6 +1,5 @@
 var path = require('path');
 var fs = require('fs');
-var streambot = require('streambot');
 var AWS = require('aws-sdk');
 var root = process.env.LAMBDA_TASK_ROOT ?
       process.env.LAMBDA_TASK_ROOT :
@@ -21,7 +20,6 @@ lambdaCfn.lambda = lambda;
 lambdaCfn.lambdaPermission = lambdaPermission;
 lambdaCfn.role = role;
 lambdaCfn.policy = policy;
-lambdaCfn.streambotEnv = streambotEnv;
 lambdaCfn.cloudwatch = cloudwatch;
 lambdaCfn.snsTopic = snsTopic;
 lambdaCfn.message = message;
@@ -89,11 +87,7 @@ function load(m, templateFilePath) {
         template.Resources[r].Metadata.sourcePath) {
       var sourcePath = path.join(root, template.Resources[r].Metadata.sourcePath);
       var rule = require(sourcePath);
-      if (process.env.NODE_ENV == 'test') {
-        m.exports[rule.config.name] = rule.fn;
-      } else {
-        m.exports[rule.config.name] = streambot(rule.fn);
-      }
+      m.exports[rule.config.name] = rule.fn;
     }
   }
 }
@@ -116,7 +110,7 @@ function build(options) {
   var resources = {};
   resources[options.name] = lambda(options);
   resources[options.name + 'Permission'] = lambdaPermission(options);
-  resources['StreambotEnv' + options.name] = streambotEnv(options);
+  resources[options.name].Properties.Resources.Variables = envVariableParser(options);
   if (options.snsRule) {
     resources[options.name + 'SNSTopic'] = lambdaSnsTopic(options);
     resources[options.name + 'SNSUser'] = lambdaSnsUser(options);
@@ -168,10 +162,6 @@ function compile(parts, template) {
   template.Parameters.GitSha = {
     Type: 'String',
     Description: 'lambda function S3 prefix location'
-  };
-  template.Parameters.StreambotEnv = {
-    Type: 'String',
-    Description: 'StreambotEnv lambda function ARN'
   };
   template.Parameters.AlarmEmail = {
     Type: 'String',
@@ -348,6 +338,9 @@ function lambda(options) {
       },
       "Description": {
         "Ref": "AWS::StackName"
+      },
+      "Resources": {
+        "Variables": {}
       },
       "Handler": "index." + options.name,
       "Runtime": options.runtime
@@ -896,18 +889,6 @@ function role() {
                 "Action": [
                   "dynamodb:GetItem"
                 ],
-                "Resource": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:dynamodb:us-east-1:",
-                      {
-                        "Ref": "AWS::AccountId"
-                      },
-                      ":table/streambot-env*"
-                    ]
-                  ]
-                }
               },
               {
                 "Effect": "Allow",
@@ -1013,35 +994,20 @@ function outputs(options) {
   return output;
 }
 
-function streambotEnv(options) {
-  if (!options.name)
-    throw new Error('name property required for streambotEnv');
+function envVariableParser(options) {
 
-    var env = {
-      "Type": "Custom::StreambotEnv",
-      "Properties": {
-        "ServiceToken": {
-          "Ref": "StreambotEnv"
-        },
-        "FunctionName": {
-          "Ref": options.name
-        }
-      }
-    };
+    var p = !options.parameters ? {} :
+        JSON.parse(JSON.stringify(parameters(options)));
 
-  var p = !options.parameters ? {} :
-      JSON.parse(JSON.stringify(parameters(options)));
-
-  // make some global env vars available
-  p.LambdaCfnAlarmSNSTopic = true;
-
-  for (var k in p) {
-    env.Properties[k] = { Ref: k };
-  }
-
-  return env;
+    // make some global env vars available
+    p.LambdaCfnAlarmSNSTopic = true;
+    console.log("JSON ----------- ");
+    console.log(p);
+    console.log("-------------End JSON");
+    return p;
 
 }
+
 
 function cloudwatch(options) {
   if (!options.name) throw new Error('name property required for cloudwatch');

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -110,7 +110,7 @@ function build(options) {
   var resources = {};
   resources[options.name] = lambda(options);
   resources[options.name + 'Permission'] = lambdaPermission(options);
-  resources[options.name].Properties.Resources.Variables = envVariableParser(options);
+  resources[options.name].Properties.Environment.Variables = envVariableParser(options);
   if (options.snsRule) {
     resources[options.name + 'SNSTopic'] = lambdaSnsTopic(options);
     resources[options.name + 'SNSUser'] = lambdaSnsUser(options);
@@ -339,7 +339,7 @@ function lambda(options) {
       "Description": {
         "Ref": "AWS::StackName"
       },
-      "Resources": {
+      "Environment": {
         "Variables": {}
       },
       "Handler": "index." + options.name,
@@ -1001,9 +1001,15 @@ function envVariableParser(options) {
 
     // make some global env vars available
     p.LambdaCfnAlarmSNSTopic = true;
-    console.log("JSON ----------- ");
+    p.StackName = { "Ref" : "AWS::StackName" };
+    p.Region = { "Ref" : "AWS::Region" };
+    p.AccountName = { "Ref" : "AWS::AccountId" };
+    p.StackId = { "Ref" : "AWS::StackId" };
+
+    console.log("PARAMETERS -------------------");
     console.log(p);
-    console.log("-------------End JSON");
+    console.log("END -------------------------");
+
     return p;
 
 }

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -35,6 +35,7 @@ lambdaCfn.apiGateway = apiGateway;
 lambdaCfn.apiDeployment = apiDeployment;
 lambdaCfn.apiKey = apiKey;
 lambdaCfn.gatewayRules = gatewayRules;
+lambdaCfn.envVariableParser = envVariableParser;
 
 function stripPunc(r) {
   return r.replace(/[^A-Za-z0-9]/g,'');

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -993,12 +993,18 @@ function envVariableParser(options) {
     var p = !options.parameters ? {} :
         JSON.parse(JSON.stringify(parameters(options)));
 
+    for (var k in p) {
+      p[k] = { Ref: k };
+    }
+
     // make some global env vars available
     p.LambdaCfnAlarmSNSTopic = true;
     p.StackName = { "Ref" : "AWS::StackName" };
     p.Region = { "Ref" : "AWS::Region" };
     p.AccountName = { "Ref" : "AWS::AccountId" };
     p.StackId = { "Ref" : "AWS::StackId" };
+
+    // Should p.FunctionName be another default?
 
     return p;
 

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -887,12 +887,6 @@ function role() {
               {
                 "Effect": "Allow",
                 "Action": [
-                  "dynamodb:GetItem"
-                ],
-              },
-              {
-                "Effect": "Allow",
-                "Action": [
                   "sns:Publish"
                 ],
                 "Resource": {
@@ -1005,10 +999,6 @@ function envVariableParser(options) {
     p.Region = { "Ref" : "AWS::Region" };
     p.AccountName = { "Ref" : "AWS::AccountId" };
     p.StackId = { "Ref" : "AWS::StackId" };
-
-    console.log("PARAMETERS -------------------");
-    console.log(p);
-    console.log("END -------------------------");
 
     return p;
 

--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -998,7 +998,7 @@ function envVariableParser(options) {
     }
 
     // make some global env vars available
-    p.LambdaCfnAlarmSNSTopic = true;
+    p.LambdaCfnAlarmSNSTopic = { "Ref": "LambdaCfnAlarmSNSTopic" };
     p.StackName = { "Ref" : "AWS::StackName" };
     p.Region = { "Ref" : "AWS::Region" };
     p.AccountName = { "Ref" : "AWS::AccountId" };

--- a/package.json
+++ b/package.json
@@ -1,48 +1,48 @@
 {
   "bin": {
     "lambda-cfn-template": "./bin/lambda-cfn-template.js"
-  }, 
-  "license": "BSD-2-Clause", 
+  },
+  "license": "BSD-2-Clause",
   "engines": {
     "node": "0.10.36 || 4.3.2"
-  }, 
-  "name": "lambda-cfn", 
+  },
+  "name": "lambda-cfn",
   "repository": {
-    "url": "https://github.com/mapbox/lambda-cfn.git", 
+    "url": "https://github.com/mapbox/lambda-cfn.git",
     "type": "git"
-  }, 
-  "author": "Mapbox, Inc.", 
-  "homepage": "https://github.com/mapbox/lambda-cfn", 
+  },
+  "author": "Mapbox, Inc.",
+  "homepage": "https://github.com/mapbox/lambda-cfn",
   "bugs": {
     "url": "https://github.com/mapbox/lambda-cfn/issues"
-  }, 
+  },
   "jscsConfig": {
-    "preset": "airbnb", 
+    "preset": "airbnb",
     "requireCamelCaseOrUpperCaseIdentifiers": null
-  }, 
-  "version": "0.1.5", 
+  },
+  "version": "0.1.5",
   "dependencies": {
-    "aws-sdk": "^2.2.35", 
-    "app-root-path": "1.2.0", 
-    "d3-queue": "^2.0.3", 
+    "aws-sdk": "^2.2.35",
+    "app-root-path": "1.2.0",
+    "d3-queue": "^2.0.3",
     "streambot": "3.4.0"
-  }, 
+  },
   "scripts": {
     "test": "NODE_ENV=test tape test/*.test.js test/**/*.test.js"
-  }, 
+  },
   "devDependencies": {
-    "tape": "^4.5.1", 
-    "jscs": "^1.11.3", 
-    "jshint": "^2.6.3", 
+    "tape": "^4.5.1",
+    "jscs": "^1.11.3",
+    "jshint": "^2.6.3",
     "nock": "^7.7.2"
-  }, 
-  "main": "lib/lambda-cfn.js", 
+  },
+  "main": "lib/lambda-cfn.js",
   "jshintConfig": {
-    "node": true, 
-    "unused": true, 
-    "globalstrict": false, 
-    "undef": true, 
+    "node": true,
+    "unused": true,
+    "globalstrict": false,
+    "undef": true,
     "noarg": true
-  }, 
+  },
   "description": "CloudFormation boiler plate for lambda functions"
 }

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -2,6 +2,8 @@ var fs = require('fs');
 var path = require('path');
 var tape = require('tape');
 var lambdaCfn = require('../lib/lambda-cfn');
+const util = require('util');
+
 
 tape('Compile unit tests', function(t) {
 
@@ -48,7 +50,14 @@ tape('Compile unit tests', function(t) {
   var fullBuilt = lambdaCfn.compile([lambdaCfn.build(fullConfig)], {});
   var fullFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/full.template'), "utf8"));
 
-  t.deepEqual(fullBuilt, fullFixture, 'full build is equal to fixture');
+    console.log("Fixture-------------------");
+    console.log(util.inspect(fullFixture, false, null));
+    console.log("Fixture-------------------");
+    console.log("Built-------------------");
+    console.log(util.inspect(fullBuilt, false, null));
+    console.log("Built-------------------");
+
+    t.deepEqual(fullBuilt, fullFixture, 'full build is equal to fixture');
 
   t.end();
 

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -50,13 +50,6 @@ tape('Compile unit tests', function(t) {
   var fullBuilt = lambdaCfn.compile([lambdaCfn.build(fullConfig)], {});
   var fullFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/full.template'), "utf8"));
 
-    console.log("Fixture-------------------");
-    console.log(util.inspect(fullFixture, false, null));
-    console.log("Fixture-------------------");
-    console.log("Built-------------------");
-    console.log(util.inspect(fullBuilt, false, null));
-    console.log("Built-------------------");
-
     t.deepEqual(fullBuilt, fullFixture, 'full build is equal to fixture');
 
   t.end();
@@ -121,7 +114,7 @@ tape('Compile Event rule', function(t) {
   var eventBuilt = lambdaCfn.compile([lambdaCfn.build(eventConfig)], {});
   var eventFixture = JSON.parse(fs.readFileSync(path.join(__dirname, './fixtures/event.template'), "utf8"));
 
-  t.deepEqual(eventBuilt,eventFixture, 'Event rule build is equal to fixture');
+    t.deepEqual(eventBuilt,eventFixture, 'Event rule build is equal to fixture');
 
   t.end();
 });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var tape = require('tape');
 var lambdaCfn = require('../lib/lambda-cfn');
-const util = require('util');
+var util = require('util');
 
 
 tape('Compile unit tests', function(t) {

--- a/test/fixtures/event.template
+++ b/test/fixtures/event.template
@@ -60,7 +60,9 @@
                         "eventRuletoken": {
                             "Ref": "eventRuletoken"
                         },
-                        "LambdaCfnAlarmSNSTopic": true,
+                        "LambdaCfnAlarmSNSTopic": {
+                            "Ref": "LambdaCfnAlarmSNSTopic"
+                        },
                         "StackName": {
                             "Ref": "AWS::StackName"
                         },

--- a/test/fixtures/event.template
+++ b/test/fixtures/event.template
@@ -55,6 +55,26 @@
                 "Description": {
                     "Ref": "AWS::StackName"
                 },
+                "Environment": {
+                    "Variables": {
+                        "eventRuletoken": {
+                            "Ref": "eventRuletoken"
+                        },
+                        "LambdaCfnAlarmSNSTopic": true,
+                        "StackName": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "Region": {
+                            "Ref": "AWS::Region"
+                        },
+                        "AccountName": {
+                            "Ref": "AWS::AccountId"
+                        },
+                        "StackId": {
+                            "Ref": "AWS::StackId"
+                        }
+                    }
+                },
                 "Handler": "index.eventRule",
                 "Runtime": "nodejs4.3",
                 "Timeout": 60,

--- a/test/fixtures/event.template
+++ b/test/fixtures/event.template
@@ -14,10 +14,6 @@
             "Type": "String",
             "Description": "lambda function S3 prefix location"
         },
-        "StreambotEnv": {
-            "Type": "String",
-            "Description": "StreambotEnv lambda function ARN"
-        },
         "AlarmEmail": {
             "Type": "String",
             "Description": "Alarm notifications will send to this email address"
@@ -98,23 +94,6 @@
                             "*"
                         ]
                     ]
-                }
-            }
-        },
-        "StreambotEnveventRule": {
-            "Type": "Custom::StreambotEnv",
-            "Properties": {
-                "ServiceToken": {
-                    "Ref": "StreambotEnv"
-                },
-                "FunctionName": {
-                    "Ref": "eventRule"
-                },
-                "eventRuletoken": {
-                    "Ref": "eventRuletoken"
-                },
-                "LambdaCfnAlarmSNSTopic": {
-                    "Ref": "LambdaCfnAlarmSNSTopic"
                 }
             }
         },
@@ -253,24 +232,6 @@
                                         "logs:*"
                                     ],
                                     "Resource": "arn:aws:logs:*:*:*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "dynamodb:GetItem"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Join": [
-                                            "",
-                                            [
-                                                "arn:aws:dynamodb:us-east-1:",
-                                                {
-                                                    "Ref": "AWS::AccountId"
-                                                },
-                                                ":table/streambot-env*"
-                                            ]
-                                        ]
-                                    }
                                 },
                                 {
                                     "Effect": "Allow",

--- a/test/fixtures/full.template
+++ b/test/fixtures/full.template
@@ -14,10 +14,6 @@
             "Type": "String",
             "Description": "lambda function S3 prefix location"
         },
-        "StreambotEnv": {
-            "Type": "String",
-            "Description": "StreambotEnv lambda function ARN"
-        },
         "AlarmEmail": {
             "Type": "String",
             "Description": "Alarm notifications will send to this email address"
@@ -66,7 +62,36 @@
                 "Handler": "index.full",
                 "Runtime": "nodejs4.3",
                 "Timeout": 60,
-                "MemorySize": 128
+                "MemorySize": 128,
+                "Environment": {
+                    "Variables": {
+                        "ServiceToken": {
+                            "Ref": "StreambotEnv"
+                        },
+                        "FunctionName": {
+                            "Ref": "full"
+                        },
+                        "fullgithubToken": {
+                            "Ref": "fullgithubToken"
+                        },
+                        "fullmyBucket": {
+                            "Ref": "fullmyBucket"
+                        },
+                        "LambdaCfnAlarmSNSTopic": true,
+                        "StackName": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "Region": {
+                            "Ref": "AWS::Region"
+                        },
+                        "AccountName": {
+                            "Ref": "AWS::AccountId"
+                        },
+                        "StackId": {
+                            "Ref": "AWS::StackId"
+                        }
+                    }
+                }
             },
             "Metadata": {
                 "sourcePath": "rules/myRule.js"
@@ -102,26 +127,6 @@
                             "*"
                         ]
                     ]
-                }
-            }
-        },
-        "StreambotEnvfull": {
-            "Type": "Custom::StreambotEnv",
-            "Properties": {
-                "ServiceToken": {
-                    "Ref": "StreambotEnv"
-                },
-                "FunctionName": {
-                    "Ref": "full"
-                },
-                "fullgithubToken": {
-                    "Ref": "fullgithubToken"
-                },
-                "fullmyBucket": {
-                    "Ref": "fullmyBucket"
-                },
-                "LambdaCfnAlarmSNSTopic": {
-                    "Ref": "LambdaCfnAlarmSNSTopic"
                 }
             }
         },
@@ -220,24 +225,6 @@
                                         "logs:*"
                                     ],
                                     "Resource": "arn:aws:logs:*:*:*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "dynamodb:GetItem"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Join": [
-                                            "",
-                                            [
-                                                "arn:aws:dynamodb:us-east-1:",
-                                                {
-                                                    "Ref": "AWS::AccountId"
-                                                },
-                                                ":table/streambot-env*"
-                                            ]
-                                        ]
-                                    }
                                 },
                                 {
                                     "Effect": "Allow",

--- a/test/fixtures/full.template
+++ b/test/fixtures/full.template
@@ -65,12 +65,6 @@
                 "MemorySize": 128,
                 "Environment": {
                     "Variables": {
-                        "ServiceToken": {
-                            "Ref": "StreambotEnv"
-                        },
-                        "FunctionName": {
-                            "Ref": "full"
-                        },
                         "fullgithubToken": {
                             "Ref": "fullgithubToken"
                         },

--- a/test/fixtures/full.template
+++ b/test/fixtures/full.template
@@ -71,7 +71,9 @@
                         "fullmyBucket": {
                             "Ref": "fullmyBucket"
                         },
-                        "LambdaCfnAlarmSNSTopic": true,
+                        "LambdaCfnAlarmSNSTopic": {
+                            "Ref": "LambdaCfnAlarmSNSTopic"
+                        },
                         "StackName": {
                             "Ref": "AWS::StackName"
                         },

--- a/test/fixtures/gateway.template
+++ b/test/fixtures/gateway.template
@@ -60,7 +60,9 @@
             "gatewayTestRuletoken": {
               "Ref": "gatewayTestRuletoken"
             },
-            "LambdaCfnAlarmSNSTopic": true,
+            "LambdaCfnAlarmSNSTopic": {
+              "Ref": "LambdaCfnAlarmSNSTopic"
+            },
             "StackName": {
               "Ref": "AWS::StackName"
             },

--- a/test/fixtures/gateway.template
+++ b/test/fixtures/gateway.template
@@ -55,6 +55,26 @@
         "Description": {
           "Ref": "AWS::StackName"
         },
+        "Environment": {
+          "Variables": {
+            "gatewayTestRuletoken": {
+              "Ref": "gatewayTestRuletoken"
+            },
+            "LambdaCfnAlarmSNSTopic": true,
+            "StackName": {
+              "Ref": "AWS::StackName"
+            },
+            "Region": {
+              "Ref": "AWS::Region"
+            },
+            "AccountName": {
+              "Ref": "AWS::AccountId"
+            },
+            "StackId": {
+              "Ref": "AWS::StackId"
+            }
+          }
+        },
         "Handler": "index.gatewayTestRule",
         "Runtime": "nodejs",
         "Timeout": 60,

--- a/test/fixtures/gateway.template
+++ b/test/fixtures/gateway.template
@@ -14,10 +14,6 @@
       "Type": "String",
       "Description": "lambda function S3 prefix location"
     },
-    "StreambotEnv": {
-      "Type": "String",
-      "Description": "StreambotEnv lambda function ARN"
-    },
     "AlarmEmail": {
       "Type": "String",
       "Description": "Alarm notifications will send to this email address"
@@ -98,23 +94,6 @@
               "/*"
             ]
           ]
-        }
-      }
-    },
-    "StreambotEnvgatewayTestRule": {
-      "Type": "Custom::StreambotEnv",
-      "Properties": {
-        "ServiceToken": {
-          "Ref": "StreambotEnv"
-        },
-        "FunctionName": {
-          "Ref": "gatewayTestRule"
-        },
-        "gatewayTestRuletoken": {
-          "Ref": "gatewayTestRuletoken"
-        },
-        "LambdaCfnAlarmSNSTopic": {
-          "Ref": "LambdaCfnAlarmSNSTopic"
         }
       }
     },
@@ -405,24 +384,6 @@
                     "logs:*"
                   ],
                   "Resource": "arn:aws:logs:*:*:*"
-                },
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "dynamodb:GetItem"
-                  ],
-                  "Resource": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "arn:aws:dynamodb:us-east-1:",
-                        {
-                          "Ref": "AWS::AccountId"
-                        },
-                        ":table/streambot-env*"
-                      ]
-                    ]
-                  }
                 },
                 {
                   "Effect": "Allow",

--- a/test/fixtures/hybrid.template
+++ b/test/fixtures/hybrid.template
@@ -14,10 +14,6 @@
             "Type": "String",
             "Description": "lambda function S3 prefix location"
         },
-        "StreambotEnv": {
-            "Type": "String",
-            "Description": "StreambotEnv lambda function ARN"
-        },
         "AlarmEmail": {
             "Type": "String",
             "Description": "Alarm notifications will send to this email address"
@@ -98,23 +94,6 @@
                             "*"
                         ]
                     ]
-                }
-            }
-        },
-        "StreambotEnvhybridRule": {
-            "Type": "Custom::StreambotEnv",
-            "Properties": {
-                "ServiceToken": {
-                    "Ref": "StreambotEnv"
-                },
-                "FunctionName": {
-                    "Ref": "hybridRule"
-                },
-                "hybridRuletoken": {
-                    "Ref": "hybridRuletoken"
-                },
-                "LambdaCfnAlarmSNSTopic": {
-                    "Ref": "LambdaCfnAlarmSNSTopic"
                 }
             }
         },
@@ -277,24 +256,6 @@
                                         "logs:*"
                                     ],
                                     "Resource": "arn:aws:logs:*:*:*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "dynamodb:GetItem"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Join": [
-                                            "",
-                                            [
-                                                "arn:aws:dynamodb:us-east-1:",
-                                                {
-                                                    "Ref": "AWS::AccountId"
-                                                },
-                                                ":table/streambot-env*"
-                                            ]
-                                        ]
-                                    }
                                 },
                                 {
                                     "Effect": "Allow",

--- a/test/fixtures/hybrid.template
+++ b/test/fixtures/hybrid.template
@@ -55,6 +55,26 @@
                 "Description": {
                     "Ref": "AWS::StackName"
                 },
+                "Environment": {
+                    "Variables": {
+                        "hybridRuletoken": {
+                            "Ref": "hybridRuletoken"
+                        },
+                        "LambdaCfnAlarmSNSTopic": true,
+                        "StackName": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "Region": {
+                            "Ref": "AWS::Region"
+                        },
+                        "AccountName": {
+                            "Ref": "AWS::AccountId"
+                        },
+                        "StackId": {
+                            "Ref": "AWS::StackId"
+                        }
+                    }
+                },
                 "Handler": "index.hybridRule",
                 "Runtime": "nodejs4.3",
                 "Timeout": 60,

--- a/test/fixtures/hybrid.template
+++ b/test/fixtures/hybrid.template
@@ -60,7 +60,9 @@
                         "hybridRuletoken": {
                             "Ref": "hybridRuletoken"
                         },
-                        "LambdaCfnAlarmSNSTopic": true,
+                        "LambdaCfnAlarmSNSTopic": {
+                            "Ref": "LambdaCfnAlarmSNSTopic"
+                        },
                         "StackName": {
                             "Ref": "AWS::StackName"
                         },

--- a/test/fixtures/scheduled.template
+++ b/test/fixtures/scheduled.template
@@ -60,7 +60,9 @@
                         "scheduledRuletoken": {
                             "Ref": "scheduledRuletoken"
                         },
-                        "LambdaCfnAlarmSNSTopic": true,
+                        "LambdaCfnAlarmSNSTopic": {
+                            "Ref": "LambdaCfnAlarmSNSTopic"
+                        },
                         "StackName": {
                             "Ref": "AWS::StackName"
                         },

--- a/test/fixtures/scheduled.template
+++ b/test/fixtures/scheduled.template
@@ -14,10 +14,6 @@
             "Type": "String",
             "Description": "lambda function S3 prefix location"
         },
-        "StreambotEnv": {
-            "Type": "String",
-            "Description": "StreambotEnv lambda function ARN"
-        },
         "AlarmEmail": {
             "Type": "String",
             "Description": "Alarm notifications will send to this email address"
@@ -98,23 +94,6 @@
                             "*"
                         ]
                     ]
-                }
-            }
-        },
-        "StreambotEnvscheduledRule": {
-            "Type": "Custom::StreambotEnv",
-            "Properties": {
-                "ServiceToken": {
-                    "Ref": "StreambotEnv"
-                },
-                "FunctionName": {
-                    "Ref": "scheduledRule"
-                },
-                "scheduledRuletoken": {
-                    "Ref": "scheduledRuletoken"
-                },
-                "LambdaCfnAlarmSNSTopic": {
-                    "Ref": "LambdaCfnAlarmSNSTopic"
                 }
             }
         },
@@ -237,24 +216,6 @@
                                         "logs:*"
                                     ],
                                     "Resource": "arn:aws:logs:*:*:*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "dynamodb:GetItem"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Join": [
-                                            "",
-                                            [
-                                                "arn:aws:dynamodb:us-east-1:",
-                                                {
-                                                    "Ref": "AWS::AccountId"
-                                                },
-                                                ":table/streambot-env*"
-                                            ]
-                                        ]
-                                    }
                                 },
                                 {
                                     "Effect": "Allow",

--- a/test/fixtures/scheduled.template
+++ b/test/fixtures/scheduled.template
@@ -55,6 +55,26 @@
                 "Description": {
                     "Ref": "AWS::StackName"
                 },
+                "Environment": {
+                    "Variables": {
+                        "scheduledRuletoken": {
+                            "Ref": "scheduledRuletoken"
+                        },
+                        "LambdaCfnAlarmSNSTopic": true,
+                        "StackName": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "Region": {
+                            "Ref": "AWS::Region"
+                        },
+                        "AccountName": {
+                            "Ref": "AWS::AccountId"
+                        },
+                        "StackId": {
+                            "Ref": "AWS::StackId"
+                        }
+                    }
+                },
                 "Handler": "index.scheduledRule",
                 "Runtime": "nodejs",
                 "Timeout": 60,

--- a/test/fixtures/simple.template
+++ b/test/fixtures/simple.template
@@ -14,10 +14,6 @@
             "Type": "String",
             "Description": "lambda function S3 prefix location"
         },
-        "StreambotEnv": {
-            "Type": "String",
-            "Description": "StreambotEnv lambda function ARN"
-        },
         "AlarmEmail": {
             "Type": "String",
             "Description": "Alarm notifications will send to this email address"
@@ -58,7 +54,24 @@
                 "Handler": "index.simple",
                 "Runtime": "nodejs4.3",
                 "Timeout": 60,
-                "MemorySize": 128
+                "MemorySize": 128,
+                "Environment": {
+                    "Variables": {
+                        "LambdaCfnAlarmSNSTopic": true,
+                        "StackName": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "Region": {
+                            "Ref": "AWS::Region"
+                        },
+                        "AccountName": {
+                            "Ref": "AWS::AccountId"
+                        },
+                        "StackId": {
+                            "Ref": "AWS::StackId"
+                        }
+                    }
+                }
             },
             "Metadata": {
                 "sourcePath": "rules/myRule.js"
@@ -94,20 +107,6 @@
                             "*"
                         ]
                     ]
-                }
-            }
-        },
-        "StreambotEnvsimple": {
-            "Type": "Custom::StreambotEnv",
-            "Properties": {
-                "ServiceToken": {
-                    "Ref": "StreambotEnv"
-                },
-                "FunctionName": {
-                    "Ref": "simple"
-                },
-                "LambdaCfnAlarmSNSTopic": {
-                    "Ref": "LambdaCfnAlarmSNSTopic"
                 }
             }
         },
@@ -206,24 +205,6 @@
                                         "logs:*"
                                     ],
                                     "Resource": "arn:aws:logs:*:*:*"
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "dynamodb:GetItem"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Join": [
-                                            "",
-                                            [
-                                                "arn:aws:dynamodb:us-east-1:",
-                                                {
-                                                    "Ref": "AWS::AccountId"
-                                                },
-                                                ":table/streambot-env*"
-                                            ]
-                                        ]
-                                    }
                                 },
                                 {
                                     "Effect": "Allow",

--- a/test/fixtures/simple.template
+++ b/test/fixtures/simple.template
@@ -57,7 +57,9 @@
                 "MemorySize": 128,
                 "Environment": {
                     "Variables": {
-                        "LambdaCfnAlarmSNSTopic": true,
+                        "LambdaCfnAlarmSNSTopic": {
+                            "Ref": "LambdaCfnAlarmSNSTopic"
+                        },
                         "StackName": {
                             "Ref": "AWS::StackName"
                         },

--- a/test/fixtures/sns.template
+++ b/test/fixtures/sns.template
@@ -14,10 +14,6 @@
             "Type": "String",
             "Description": "lambda function S3 prefix location"
         },
-        "StreambotEnv": {
-            "Type": "String",
-            "Description": "StreambotEnv lambda function ARN"
-        },
         "AlarmEmail": {
             "Type": "String",
             "Description": "Alarm notifications will send to this email address"
@@ -81,23 +77,6 @@
                 "Principal": "sns.amazonaws.com",
                 "SourceArn": {
                     "Ref": "snsSNSTopic"
-                }
-            }
-        },
-        "StreambotEnvsns": {
-            "Type": "Custom::StreambotEnv",
-            "Properties": {
-                "ServiceToken": {
-                    "Ref": "StreambotEnv"
-                },
-                "FunctionName": {
-                    "Ref": "sns"
-                },
-                "snstoken": {
-                    "Ref": "snstoken"
-                },
-                "LambdaCfnAlarmSNSTopic": {
-                    "Ref": "LambdaCfnAlarmSNSTopic"
                 }
             }
         },

--- a/test/fixtures/sns.template
+++ b/test/fixtures/sns.template
@@ -55,6 +55,26 @@
                 "Description": {
                     "Ref": "AWS::StackName"
                 },
+                "Environment": {
+                    "Variables": {
+                        "snstoken": {
+                            "Ref": "snstoken"
+                        },
+                        "LambdaCfnAlarmSNSTopic": true,
+                        "StackName": {
+                            "Ref": "AWS::StackName"
+                        },
+                        "Region": {
+                            "Ref": "AWS::Region"
+                        },
+                        "AccountName": {
+                            "Ref": "AWS::AccountId"
+                        },
+                        "StackId": {
+                            "Ref": "AWS::StackId"
+                        }
+                    }
+                },
                 "Handler": "index.sns",
                 "Runtime": "nodejs",
                 "Timeout": 60,

--- a/test/fixtures/sns.template
+++ b/test/fixtures/sns.template
@@ -60,7 +60,9 @@
                         "snstoken": {
                             "Ref": "snstoken"
                         },
-                        "LambdaCfnAlarmSNSTopic": true,
+                        "LambdaCfnAlarmSNSTopic": {
+                            "Ref": "LambdaCfnAlarmSNSTopic"
+                        },
                         "StackName": {
                             "Ref": "AWS::StackName"
                         },

--- a/test/fixtures/sns.template
+++ b/test/fixtures/sns.template
@@ -276,24 +276,6 @@
                                 {
                                     "Effect": "Allow",
                                     "Action": [
-                                        "dynamodb:GetItem"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Join": [
-                                            "",
-                                            [
-                                                "arn:aws:dynamodb:us-east-1:",
-                                                {
-                                                    "Ref": "AWS::AccountId"
-                                                },
-                                                ":table/streambot-env*"
-                                            ]
-                                        ]
-                                    }
-                                },
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
                                         "sns:Publish"
                                     ],
                                     "Resource": {

--- a/test/lambda-cfn.test.js
+++ b/test/lambda-cfn.test.js
@@ -5,7 +5,6 @@ var parameters = lambdaCfn.parameters;
 var lambda = lambdaCfn.lambda;
 var lambdaPermission = lambdaCfn.lambdaPermission;
 var policy = lambdaCfn.policy;
-var streambotEnv = lambdaCfn.streambotEnv;
 var cloudwatch = lambdaCfn.cloudwatch;
 var splitOnComma = lambdaCfn.splitOnComma;
 var lambdaSnsTopic = lambdaCfn.lambdaSnsTopic;
@@ -215,76 +214,6 @@ tape('policy unit tests', function(t) {
 
   t.end();
 
-});
-
-tape('streambotEnv unit tests', function(t) {
-  t.throws(
-    function() {
-      streambotEnv({});
-    }, /name property required for streambotEnv/,
-      'Fail in streambotEnv when no name property'
-
-  );
-
-  var onlyGlobalStreambotEnv;
-
-  t.doesNotThrow(
-    function() {
-      onlyGlobalStreambotEnv = streambotEnv({name: 'myFunction'});
-    }, null, 'Does not throw if no parameters');
-
-  t.deepEqual(onlyGlobalStreambotEnv, {
-      "Type": "Custom::StreambotEnv",
-      "Properties": {
-        "ServiceToken": {
-          "Ref": "StreambotEnv"
-        },
-        "FunctionName": {
-          "Ref": "myFunction"
-        },
-        "LambdaCfnAlarmSNSTopic": {
-          "Ref": "LambdaCfnAlarmSNSTopic"
-        }
-      }
-    }, 'Only global streambotEnv if no parameters');
-
-  var validStreambotEnv = streambotEnv({
-    name: 'myFunction',
-    parameters: {
-      param1: {
-        Type: 'String',
-        Description: 'desc 1'
-      },
-      param2: {
-        Type: 'String',
-        Description: 'desc 2'
-      }
-    }
-  });
-
-  t.deepEqual(validStreambotEnv, {
-      "Type": "Custom::StreambotEnv",
-      "Properties": {
-        "ServiceToken": {
-          "Ref": "StreambotEnv"
-        },
-        "FunctionName": {
-          "Ref": "myFunction"
-        },
-        "myFunctionparam1": {
-          "Ref": "myFunctionparam1"
-        },
-        "myFunctionparam2": {
-          "Ref": "myFunctionparam2"
-        },
-        "LambdaCfnAlarmSNSTopic": {
-          "Ref": "LambdaCfnAlarmSNSTopic"
-        }
-      }
-    }
-  );
-
-  t.end();
 });
 
 tape('cloudwatch unit tests', function(t) {

--- a/test/lambda-cfn.test.js
+++ b/test/lambda-cfn.test.js
@@ -502,7 +502,7 @@ tape('envVariableParser unit tests', function(t) {
             "StackId": {"Ref": "AWS::StackId"},
             "StackName": {"Ref": "AWS::StackName"}
         },
-        'Only global streambotEnv if no parameters');
+        'Only global env variables if no parameters');
 
     var validEnvVariables = envVariableParser({
         name: 'myFunction',
@@ -528,7 +528,7 @@ tape('envVariableParser unit tests', function(t) {
             "StackId": {"Ref": "AWS::StackId"},
             "StackName": {"Ref": "AWS::StackName"}
         },
-        'Only global streambotEnv if no parameters');
+        'Global plus function env variables set');
 
     t.end();
 });


### PR DESCRIPTION
This PR is to address AWS' new feature of native environment variables for lambda (http://docs.aws.amazon.com/lambda/latest/dg/env_variables.html) as well as removing the now depreciated streambot.

With the removal of streambot functions handed to lambda-cfn need to be written according to the Lambda Nodejs programming model: http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html

This will require minimal refactoring for projects on Node4 and for projects using Node 0.10 + streambot refactoring should be small refactoring around moving to Node4. 
