### PR TITLE
[WIP] Init and deploy commands for new functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 sudo: false
 node_js:
-- 0.10.36
 - 4.3.2
+- 6.10.2

--- a/bin/init.js
+++ b/bin/init.js
@@ -31,11 +31,13 @@ function checkPackageJson() {
 
 function createFunctionFiles() {
   // TODO - validate name against CloudFormation stack name limitations
+  // Must contain only letters, numbers, dashes and start with an alpha character.
   var directoryName = argv._[2];
   fs.mkdir(directoryName, function(err, response) {
     if (err) throw (err);
     process.chdir(directoryName);
     var files = fs.readdirSync(process.cwd());
+    
     if (files.indexOf('function.js') === -1) {
       var functionJsContent = 'var lambdaCfn = require(\'lambda-cfn\'); \n\n'
         + 'module.exports.fn = function(event, context, callback) { \n'
@@ -45,8 +47,13 @@ function createFunctionFiles() {
         console.log('Created ' + directoryName + '/function.js file')
       });
     }
+
     if (files.indexOf('function.template.js') === -1) {
-      fs.writeFile('function.template.js', 'function.template.js file', function(err, file){
+      var functionTemplateContent = 'var lambdaCfn = require(\'lambda-cfn\'); \n\n'
+        + 'module.exports = lambdaCfn.build({\n'
+        + '  name: \'' + directoryName + '\'\n'
+        + '});';
+      fs.writeFile('function.template.js', functionTemplateContent, function(err, file){
         if (err) throw err;
         console.log('Created ' + directoryName + '/function.template.js file')
       });

--- a/bin/init.js
+++ b/bin/init.js
@@ -37,12 +37,15 @@ function createFunctionFiles() {
     process.chdir(directoryName);
     var files = fs.readdirSync(process.cwd());
     if (files.indexOf('function.js') === -1) {
-      fs.writeFile('function.js', 'function.js file', function(err, file){
+      var functionJsContent = 'var lambdaCfn = require(\'lambda-cfn\'); \n\n'
+        + 'module.exports.fn = function(event, context, callback) { \n'
+        + '// write Lambda function code here \n \n};';
+      fs.writeFile('function.js', functionJsContent, function(err, file){
         if (err) throw err;
         console.log('Created ' + directoryName + '/function.js file')
       });
     }
-    if (files.indexOf('function.js') === -1) {
+    if (files.indexOf('function.template.js') === -1) {
       fs.writeFile('function.template.js', 'function.template.js file', function(err, file){
         if (err) throw err;
         console.log('Created ' + directoryName + '/function.template.js file')

--- a/bin/init.js
+++ b/bin/init.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+var fs = require('fs');
+var path = require('path');
+var argv = require('minimist')(process.argv);
+
+if (!argv._[2]) {
+  console.log('Please provide a name for the function');
+  process.exit(1);
+}
+
+function checkPackageJson() {
+  var directoryName = path.basename(process.cwd());
+  var files = fs.readdirSync(process.cwd());
+  if (files.indexOf('package.json') === -1) {
+    var content = {
+      "name": directoryName,
+      "version": "0.0.0",
+      "dependencies": {
+        "lambda-cfn": "*"
+      }
+    };
+    fs.writeFile('package.json', JSON.stringify(content, null, 2), function(err, file) {
+      if (err) throw err;
+      console.log('Created package.json file');
+    });
+  } else {
+    console.log('Package.json file already in this directory');
+    // TODO add checks for valid package.json and required dependencies
+  }
+}
+
+function createFunctionFiles() {
+  // TODO - validate name against CloudFormation stack name limitations
+  var directoryName = argv._[2];
+  fs.mkdir(directoryName, function(err, response) {
+    if (err) throw (err);
+    process.chdir(directoryName);
+    var files = fs.readdirSync(process.cwd());
+    if (files.indexOf('function.js') === -1) {
+      fs.writeFile('function.js', 'function.js file', function(err, file){
+        if (err) throw err;
+        console.log('Created ' + directoryName + '/function.js file')
+      });
+    }
+    if (files.indexOf('function.js') === -1) {
+      fs.writeFile('function.template.js', 'function.template.js file', function(err, file){
+        if (err) throw err;
+        console.log('Created ' + directoryName + '/function.template.js file')
+      });
+    }
+  });
+}
+
+checkPackageJson();
+createFunctionFiles();

--- a/bin/lambda-cfn-deploy.js
+++ b/bin/lambda-cfn-deploy.js
@@ -15,34 +15,4 @@ if (!argv._[3]) {
 var command = argv._[2];
 var environment = argv._[3];
 
-if (argv.name) {
-  var stackName = argv.name;
-} else {
-  var stackName = path.basename(process.cwd());
-}
-
-if (argv.template) {
-  var template = argv.template;
-} else {
-  var template = path.join(process.cwd(), 'function.template.js');
-}
-
-if (argv.cfnConfigbucket) {
-  var cfnConfigBucket = argv.cfnConfigbucket;
-} else {
-  var cfnConfigBucket = process.env.CFN_CONFIG_BUCKET;
-}
-
-if (argv.region) {
-  var region = argv.region;
-} else {
-  var region = process.env.AWS_DEFAULT_REGION;
-}
-
-if (argv.templateBucket) {
-  var templateBucket = argv.templateBucket;
-} else {
-  var templateBucket = 'cfn-config-templates-' + process.env.AWS_ACCOUNT_ID + '-' + region;
-}
-
-lambdaCfnDeploy.deploy(command, stackName, environment, template, region, cfnConfigBucket, templateBucket);
+lambdaCfnDeploy.deploy(command, environment, argv.name, argv.template, argv.region, argv.cfnConfigbucket, argv.templateBucket);

--- a/bin/lambda-cfn-deploy.js
+++ b/bin/lambda-cfn-deploy.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+var path = require('path');
+var argv = require('minimist')(process.argv);
+var lambdaCfnDeploy = require('../lib/deploy.js');
+
+if (!argv._[2]) {
+  console.log('Please provide a deployment command');
+  process.exit(1);
+}
+if (!argv._[3]) {
+  console.log('Please provide an environment name');
+  process.exit(1);
+}
+
+var command = argv._[2];
+var environment = argv._[3];
+
+if (argv.name) {
+  var stackName = argv.name;
+} else {
+  var stackName = path.basename(process.cwd());
+}
+
+if (argv.template) {
+  var template = argv.template;
+} else {
+  var template = path.join(process.cwd(), 'function.template.js');
+}
+
+if (argv.cfnConfigbucket) {
+  var cfnConfigBucket = argv.cfnConfigbucket;
+} else {
+  var cfnConfigBucket = process.env.CFN_CONFIG_BUCKET;
+}
+
+if (argv.region) {
+  var region = argv.region;
+} else {
+  var region = process.env.AWS_DEFAULT_REGION;
+}
+
+if (argv.templateBucket) {
+  var templateBucket = argv.templateBucket;
+} else {
+  var templateBucket = 'cfn-config-templates-' + process.env.AWS_ACCOUNT_ID + '-' + region;
+}
+
+lambdaCfnDeploy.deploy(command, stackName, environment, template, region, cfnConfigBucket, templateBucket);

--- a/bin/lambda-cfn-init.js
+++ b/bin/lambda-cfn-init.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+var argv = require('minimist')(process.argv);
+var lambdaCfnInit = require('../lib/init.js');
+
+if (!argv._[2]) {
+  console.log('Please provide a name for the function');
+  process.exit(1);
+}
+
+lambdaCfnInit.init(argv._[2]);

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -15,7 +15,7 @@ function deploy(command, stackName, environment, template, region, cfnConfigBuck
   var commands = cfnConfig.commands(options);
 
   var overrides = {
-    parameters: { GitSha: git.long() },
+    parameters: { GitSha: git.long(process.cwd()) },
   };
 
   switch (command) {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,0 +1,49 @@
+module.exports.deploy = deploy;
+
+var cfnConfig = require('@mapbox/cfn-config');
+
+function deploy(command, stackName, environment, template, region, cfnConfigBucket, templateBucket) {
+
+  var options = {
+    name: stackName,
+    region: region,
+    configBucket: cfnConfigBucket,
+    templateBucket: templateBucket
+  }
+
+  var commands = cfnConfig.commands(options);
+
+  switch (command) {
+    case 'create':
+      commands.create(environment, template, function (err) {
+        if (err) console.error(`Create failed: ${err.message}`);
+        else console.log('Create succeeded');
+      });
+      break;
+    case 'update':
+      commands.update(environment, template, function (err) {
+        if (err) console.error(`Update failed: ${err.message}`);
+        else console.log('Update succeeded');
+      });
+      break;
+    case 'save':
+      commands.save(environment, function (err) {
+        if (err) console.error(`Failed to save configuration: ${err.message}`);
+        else console.log('Saved configuration');
+      });
+      break;
+    case 'info':
+      commands.info(environment, function(err, info) {
+        if (err) console.error(`Failed to read stack info: ${err.message}`);
+        else console.log(JSON.stringify(info, null, 2));
+      });
+      break;
+    case 'delete':
+      commands.delete(environment, function(err) {
+        if (err) console.error(`Delete failed: ${err.message}`);
+        else console.log('Delete succeeded');
+      });
+      break;
+  }
+
+}

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -2,8 +2,37 @@ module.exports.deploy = deploy;
 
 var cfnConfig = require('@mapbox/cfn-config');
 var git = require('git-rev-sync');
+var path = require('path');
 
-function deploy(command, stackName, environment, template, region, cfnConfigBucket, templateBucket) {
+function deploy(command, environment, stackName, template, region, cfnConfigBucket, templateBucket) {
+
+  if (command === undefined) {
+    throw new Error('Please provide a valid deployment command');
+  }
+  if (environment === undefined) {
+    throw new Error('Please provide an environment name');
+  }
+  if (stackName === undefined) {
+    stackName = path.basename(process.cwd());
+  }
+  if (template === undefined) {
+    template = path.join(process.cwd(), 'function.template.js');
+  }
+  if (region === undefined) {
+    region = process.env.AWS_DEFAULT_REGION;
+  }
+  if (cfnConfigBucket === undefined) {
+    if (process.env.CFN_CONFIG_BUCKET === undefined) {
+      throw new Error('$CFN_CONFIG_BUCKET not defined and cfn-config S3 bucket not provided');
+    }
+    cfnConfigBucket = process.env.CFN_CONFIG_BUCKET;
+  }
+  if (templateBucket === undefined) {
+    if (process.env.AWS_ACCOUNT_ID === undefined) {
+      throw new Error('$AWS_ACCOUNT_ID not defined and template S3 bucket not provided');
+    }
+    templateBucket = 'cfn-config-templates-' + process.env.AWS_ACCOUNT_ID + '-' + region;;
+  }
 
   var options = {
     name: stackName,

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,6 +1,7 @@
 module.exports.deploy = deploy;
 
 var cfnConfig = require('@mapbox/cfn-config');
+var git = require('git-rev-sync');
 
 function deploy(command, stackName, environment, template, region, cfnConfigBucket, templateBucket) {
 
@@ -13,9 +14,13 @@ function deploy(command, stackName, environment, template, region, cfnConfigBuck
 
   var commands = cfnConfig.commands(options);
 
+  var overrides = {
+    parameters: { GitSha: git.long() },
+  };
+
   switch (command) {
     case 'create':
-      commands.create(environment, template, function (err) {
+      commands.create(environment, template, overrides, function (err) {
         if (err) console.error(`Create failed: ${err.message}`);
         else console.log('Create succeeded');
       });

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,12 +1,7 @@
-#!/usr/bin/env node
+module.exports.init = init;
+
 var fs = require('fs');
 var path = require('path');
-var argv = require('minimist')(process.argv);
-
-if (!argv._[2]) {
-  console.log('Please provide a name for the function');
-  process.exit(1);
-}
 
 function checkPackageJson() {
   var directoryName = path.basename(process.cwd());
@@ -29,13 +24,12 @@ function checkPackageJson() {
   }
 }
 
-function createFunctionFiles() {
+function createFunctionFiles(name) {
   // TODO - validate name against CloudFormation stack name limitations
   // Must contain only letters, numbers, dashes and start with an alpha character.
-  var directoryName = argv._[2];
-  fs.mkdir(directoryName, function(err, response) {
+  fs.mkdir(name, function(err, response) {
     if (err) throw (err);
-    process.chdir(directoryName);
+    process.chdir(name);
     var files = fs.readdirSync(process.cwd());
     
     if (files.indexOf('function.js') === -1) {
@@ -44,22 +38,24 @@ function createFunctionFiles() {
         + '// write Lambda function code here \n \n};';
       fs.writeFile('function.js', functionJsContent, function(err, file){
         if (err) throw err;
-        console.log('Created ' + directoryName + '/function.js file')
+        console.log('Created ' + name + '/function.js file')
       });
     }
 
     if (files.indexOf('function.template.js') === -1) {
       var functionTemplateContent = 'var lambdaCfn = require(\'lambda-cfn\'); \n\n'
         + 'module.exports = lambdaCfn.build({\n'
-        + '  name: \'' + directoryName + '\'\n'
+        + '  name: \'' + name + '\'\n'
         + '});';
       fs.writeFile('function.template.js', functionTemplateContent, function(err, file){
         if (err) throw err;
-        console.log('Created ' + directoryName + '/function.template.js file')
+        console.log('Created ' + name + '/function.template.js file')
       });
     }
   });
 }
 
-checkPackageJson();
-createFunctionFiles();
+function init(name) {
+  checkPackageJson();
+  createFunctionFiles(name);
+}

--- a/lib/init.js
+++ b/lib/init.js
@@ -25,8 +25,13 @@ function checkPackageJson() {
 }
 
 function createFunctionFiles(name) {
-  // TODO - validate name against CloudFormation stack name limitations
-  // Must contain only letters, numbers, dashes and start with an alpha character.
+  
+  var regExp = /^[a-zA-Z][a-zA-Z0-9-]+$/;
+  
+  if (name.match(regExp) === null) {
+    throw new Error('Not a valid AWS CloudFormation stack name - must contain only letters, numbers, dashes and start with an alpha character');
+  }
+
   fs.mkdir(name, function(err, response) {
     if (err) throw (err);
     process.chdir(name);

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,9 +1,11 @@
 module.exports.init = init;
+module.exports.checkPackageJson = checkPackageJson;
+module.exports.createFunctionFiles = createFunctionFiles;
 
 var fs = require('fs');
 var path = require('path');
 
-function checkPackageJson() {
+function checkPackageJson(callback) {
   var directoryName = path.basename(process.cwd());
   var files = fs.readdirSync(process.cwd());
   if (files.indexOf('package.json') === -1) {
@@ -16,18 +18,18 @@ function checkPackageJson() {
     };
     fs.writeFile('package.json', JSON.stringify(content, null, 2), function(err, file) {
       if (err) throw err;
-      console.log('Created package.json file');
+      callback(null, 'Created package.json file');
     });
   } else {
-    console.log('Package.json file already in this directory');
+    callback(null, 'Package.json file already exists');
     // TODO add checks for valid package.json and required dependencies
   }
 }
 
-function createFunctionFiles(name) {
+function createFunctionFiles(name, callback) {
   
   var regExp = /^[a-zA-Z][a-zA-Z0-9-]+$/;
-  
+
   if (name.match(regExp) === null) {
     throw new Error('Not a valid AWS CloudFormation stack name - must contain only letters, numbers, dashes and start with an alpha character');
   }
@@ -36,31 +38,36 @@ function createFunctionFiles(name) {
     if (err) throw (err);
     process.chdir(name);
     var files = fs.readdirSync(process.cwd());
-    
     if (files.indexOf('function.js') === -1) {
       var functionJsContent = 'var lambdaCfn = require(\'lambda-cfn\'); \n\n'
         + 'module.exports.fn = function(event, context, callback) { \n'
         + '// write Lambda function code here \n \n};';
+      
       fs.writeFile('function.js', functionJsContent, function(err, file){
         if (err) throw err;
-        console.log('Created ' + name + '/function.js file')
-      });
-    }
+        if (files.indexOf('function.template.js') === -1) {
+          var functionTemplateContent = 'var lambdaCfn = require(\'lambda-cfn\'); \n\n'
+            + 'module.exports = lambdaCfn.build({\n'
+            + '  name: \'' + name + '\'\n'
+            + '});';
 
-    if (files.indexOf('function.template.js') === -1) {
-      var functionTemplateContent = 'var lambdaCfn = require(\'lambda-cfn\'); \n\n'
-        + 'module.exports = lambdaCfn.build({\n'
-        + '  name: \'' + name + '\'\n'
-        + '});';
-      fs.writeFile('function.template.js', functionTemplateContent, function(err, file){
-        if (err) throw err;
-        console.log('Created ' + name + '/function.template.js file')
+          fs.writeFile('function.template.js', functionTemplateContent, function(err, file){
+            if (err) throw err;
+            callback(null, 'Created ' + name + '/function.js and ' + name + '/function.template.js files');
+          });
+        }
       });
     }
   });
 }
 
 function init(name) {
-  checkPackageJson();
-  createFunctionFiles(name);
+  checkPackageJson(function(err, res){ 
+    if (err) console.log(err);
+    console.log(res);
+  });
+  createFunctionFiles(name, function(err, res){
+    if (err) console.log(err);
+    console.log(res);
+  });
 }

--- a/lib/init.js
+++ b/lib/init.js
@@ -4,6 +4,7 @@ module.exports.createFunctionFiles = createFunctionFiles;
 
 var fs = require('fs');
 var path = require('path');
+var _ = require('lodash');
 
 function checkPackageJson(callback) {
   var directoryName = path.basename(process.cwd());
@@ -21,8 +22,19 @@ function checkPackageJson(callback) {
       callback(null, 'Created package.json file');
     });
   } else {
-    callback(null, 'Package.json file already exists');
-    // TODO add checks for valid package.json and required dependencies
+    fs.readFile('package.json', 'utf-8', function(err, data){
+      if (err) console.error(err)
+      var content = JSON.parse(data);
+      var dependencies = Object.keys(content.dependencies);
+      if (_.includes(dependencies, 'lambda-cfn')) {
+        callback(null, 'Package.json already exists and lambda-cfn is a dependency');
+      } else {
+        var newDependencies = _.assign(content.dependencies, {'lambda-cfn': '*'});
+        fs.writeFile('package.json', JSON.stringify(content, null, 2), function(err){
+          callback(null, 'Added lambda-cfn as a dependency to existing package.json');
+        });
+      }
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "bin": {
-    "lambda-cfn-template": "./bin/lambda-cfn-template.js"
+    "lambda-cfn-template": "./bin/lambda-cfn-template.js",
+    "lambda-cfn-init": "bin/init.js"
   },
   "license": "BSD-2-Clause",
   "engines": {
@@ -22,9 +23,10 @@
   },
   "version": "1.0.0",
   "dependencies": {
-    "aws-sdk": "^2.2.35",
     "app-root-path": "1.2.0",
+    "aws-sdk": "^2.2.35",
     "d3-queue": "^2.0.3",
+    "minimist": "^1.2.0",
     "streambot": "3.4.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "bin": {
     "lambda-cfn-template": "./bin/lambda-cfn-template.js",
-    "lambda-cfn-init": ".bin/lambda-cfn-init.js"
+    "lambda-cfn-init": "./bin/lambda-cfn-init.js",
+    "lambda-cfn-deploy": "./bin/lambda-cfn-deploy.js"
   },
   "license": "BSD-2-Clause",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "version": "1.0.0",
   "dependencies": {
+    "@mapbox/cfn-config": "^2.7.1",
     "app-root-path": "1.2.0",
     "aws-sdk": "^2.2.35",
     "d3-queue": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "aws-sdk": "^2.2.35",
     "d3-queue": "^2.0.3",
     "git-rev-sync": "^1.9.1",
+    "lodash": "^4.17.4",
     "minimist": "^1.2.0",
     "rimraf": "^2.6.1",
     "streambot": "3.4.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "app-root-path": "1.2.0",
     "aws-sdk": "^2.2.35",
     "d3-queue": "^2.0.3",
+    "git-rev-sync": "^1.9.1",
     "minimist": "^1.2.0",
     "streambot": "3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "license": "BSD-2-Clause",
   "engines": {
-    "node": "0.10.36 || 4.3.2"
+    "node": "4.3.2 || 6.10.2"
   },
   "name": "lambda-cfn",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "bin": {
     "lambda-cfn-template": "./bin/lambda-cfn-template.js",
-    "lambda-cfn-init": "bin/init.js"
+    "lambda-cfn-init": ".bin/lambda-cfn-init.js"
   },
   "license": "BSD-2-Clause",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "d3-queue": "^2.0.3",
     "git-rev-sync": "^1.9.1",
     "minimist": "^1.2.0",
+    "rimraf": "^2.6.1",
     "streambot": "3.4.0"
   },
   "scripts": {

--- a/test/deploy.test.js
+++ b/test/deploy.test.js
@@ -15,7 +15,6 @@ tape('Deployment fails without an environment name', function(t){
 });
 
 tape('Deployment fails if cfn config bucket not defined and $CFN_CONFIG_BUCKET is undefined', function(t) {
-  console.log(path.join(__dirname, 'fixtures/deploy'));
   process.chdir(path.join(__dirname, 'fixtures/deploy'));
   delete process.env.CFN_CONFIG_BUCKET;
   t.throws(function() { lambdaCfnDeploy.deploy('create', 'development') });

--- a/test/deploy.test.js
+++ b/test/deploy.test.js
@@ -1,0 +1,31 @@
+var tape = require('tape');
+var lambdaCfnDeploy = require('../lib/deploy.js');
+var path = require('path');
+
+process.env.AWS_ACCOUNT_ID = 'fakefakefake';
+
+tape('Deployment fails without a deployment command', function(t){
+  t.throws(function() { lambdaCfnDeploy.deploy(); });
+  t.end();
+});
+
+tape('Deployment fails without an environment name', function(t){
+  t.throws(function() { lambdaCfnDeploy.deploy('create'); });
+  t.end();
+});
+
+tape('Deployment fails if cfn config bucket not defined and $CFN_CONFIG_BUCKET is undefined', function(t) {
+  console.log(path.join(__dirname, 'fixtures/deploy'));
+  process.chdir(path.join(__dirname, 'fixtures/deploy'));
+  delete process.env.CFN_CONFIG_BUCKET;
+  t.throws(function() { lambdaCfnDeploy.deploy('create', 'development') });
+  t.end();
+});
+
+tape('Deployment fails if template bucket not defined and $AWS_ACCOUNT_ID is undefined', function(t) {
+  process.env.CFN_CONFIG_BUCKET = 'fakefakefake';
+  delete process.env.AWS_ACCOUNT_ID;
+  t.throws(function() { lambdaCfnDeploy.deploy('create', 'development') });
+  process.chdir('../../..');
+  t.end();
+});

--- a/test/fixtures/deploy/function.template.js
+++ b/test/fixtures/deploy/function.template.js
@@ -1,0 +1,5 @@
+var lambdaCfn = require('../../../lib/lambda-cfn.js'); 
+
+module.exports = lambdaCfn.build({
+  name: 'fakeFakeRule'
+});

--- a/test/fixtures/init/incomplete/package.json
+++ b/test/fixtures/init/incomplete/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "incomplete",
+  "version": "0.0.0",
+  "dependencies": {
+    "request": "2.81.0",
+    "express": "4.15.3"
+  }
+}

--- a/test/fixtures/init/package.json
+++ b/test/fixtures/init/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fake-rules-project",
+  "version": "0.0.0",
+  "dependencies": {
+    "lambda-cfn": "*"
+  }
+}

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -51,6 +51,12 @@ tape('Create function directory and files', function(t) {
   });
 });
 
+tape('Creating function with bad stack name fails', function(t) {
+  t.throws(function() { lambdaCfnInit.createFunctionFiles('123-badRule', 
+    function(err, res){ }) },/Not a valid AWS CloudFormation stack name - must contain only letters, numbers, dashes and start with an alpha character/);
+  t.end();
+});
+
 tape('Teardown', function(t) {
   process.chdir('..');
   rimraf('anotherFakeRule', function(err){

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,0 +1,63 @@
+var tape = require('tape');
+var fs = require('fs');
+var rimraf = require('rimraf');
+var path = require('path');
+var lambdaCfnInit = require('../lib/init.js');
+
+var currentDirectory = path.basename(process.cwd());
+
+// Support running tests from both `npm test` or `node init.test.js` from test folder
+switch (currentDirectory) {
+  case 'lambda-cfn':
+    var initialDirectory = 'test/fixtures/init/';
+    break;
+  case 'test':
+    var initialDirectory = 'fixtures/init/';
+    break;
+  default:
+    throw new Error('Please run tests via npm test or directly from the test directory');
+}
+
+tape('Check for existing package.json', function(t) {
+  process.chdir(initialDirectory);
+  lambdaCfnInit.checkPackageJson(function (err, res){
+    t.error(err, 'Does not error');
+    t.equal(res, 'Package.json file already exists');
+    process.chdir(__dirname);
+    t.end();
+  });
+});
+
+tape('Create new package.json', function(t) {
+  // current working directory is now /lambda-cfn/test
+  process.chdir('fixtures/init/');
+  fs.mkdir('anotherFakeRule', function (err, response) {
+    process.chdir('anotherFakeRule');
+    lambdaCfnInit.checkPackageJson(function (err, res) {
+      t.error(err, 'Does not error');
+      t.equal(res, 'Created package.json file');
+      process.chdir(__dirname);
+      t.end();
+    });
+  });
+});
+
+tape('Create function directory and files', function(t) {
+  process.chdir('fixtures/init/');
+  lambdaCfnInit.createFunctionFiles('fakeFakeRule', function(err, res) {
+    t.error(err, 'Does not error');
+    t.equal(res, 'Created fakeFakeRule/function.js and fakeFakeRule/function.template.js files')
+    t.end();
+  });
+});
+
+tape('Teardown', function(t) {
+  process.chdir('..');
+  rimraf('anotherFakeRule', function(err){
+    if (err) console.log(err);
+    rimraf('fakeFakeRule', function(err){
+      if (err) console.log(err);
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
Working on https://github.com/mapbox/lambda-cfn/issues/45 in this branch. See https://github.com/mapbox/lambda-cfn/issues/47 for additional context.

So far this branch creates a `package.json` file if it doesn't exist already and adds lambda-cfn as a dependency. It also creates a directory for the function based on a user provided name and creates a `function.js` and `function.template.js` file in that directory.

To run this bin script - `lambda-cfn-init <function name>`.

More things to do in this PR that I'll be working on this week (incomplete list):

- [x] Add checks for existing `package.json` file
- [x] Validate function name for CloudFormation stack name compatibility
- [x] Add script content for `function.js` (see [this branch of patrol-rules-aws for an example](https://github.com/mapbox/patrol-rules-aws/blob/1r1s/cloudfrontModifyDelete/function.js))
- [x] Add script content for `function.template.js` (see [this branch of patrol-rules-aws for an example](https://github.com/mapbox/patrol-rules-aws/blob/1r1s/cloudfrontModifyDelete/function.template.js))
- [x] Add tests

/cc @ianshward @zmully 