### PR TITLE
Fixing a global variable

### DIFF
--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -96,7 +96,7 @@ function load(m, templateFilePath) {
 function embed(lambdaPaths, template) {
   var parts = [];
   lambdaPaths.forEach(function(lambdaPath) {
-    config = require(path.join(root, lambdaPath)).config;
+    var config = require(path.join(root, lambdaPath)).config;
     config.name = namespace(config.name,lambdaPath);
     config.sourcePath = lambdaPath;
     parts.push(build(config));


### PR DESCRIPTION
So, I re-installed mbxcli yesterday (July 31st) and was not able to deploy a new service. After some stack tracing (with @ianshward wonderful sleuthing assistance), we found the root cause of the error:

```
01:55:22Z us-east-1: creating stack dispatch-olivia
/Users/oliikit/Mapbox/dispatch/node_modules/lambda-cfn/lib/lambda-cfn.js:99
    config = require(path.join(root, lambdaPath)).config;
           ^

ReferenceError: config is not defined
    at /Users/oliikit/Mapbox/dispatch/node_modules/lambda-cfn/lib/lambda-cfn.js:99:12
    at Array.forEach (native)
    at embed (/Users/oliikit/Mapbox/dispatch/node_modules/lambda-cfn/lib/lambda-cfn.js:98:15)
    at Object.<anonymous> (/Users/oliikit/Mapbox/dispatch/cloudformation/dispatch.template.js:3:18)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
```

I changed line 99 to a local variable, and I was able to deploy! 🎉 

@ianshward et al (@mapbox/security) have not encountered this situation - only me. So 🤷‍♀️. But this PR is to make sure it doesn't happen again!