### PR TITLE
Avoid SNS topic name collision

### DIFF
--- a/lib/lambda-cfn.js
+++ b/lib/lambda-cfn.js
@@ -854,7 +854,7 @@ function buildAlarmSnsTopic(options) {
       LambdaCfnAlarmSNSTopic: {
         Type: 'AWS::SNS::Topic',
         Properties: {
-          TopicName: cf.stackName,
+          TopicName: cf.join('-', [cf.stackName, 'alarms']),
           Subscription: [
             {
               Endpoint: cf.ref('ServiceAlarmEmail'),
@@ -904,7 +904,7 @@ function buildSnsDestination(options) {
   sns.Resources[options.name + 'SNSDestination'] = {
     Type: 'AWS::SNS::Topic',
     Properties: {
-      TopicName: cf.stackName,
+      TopicName: cf.join('-', [cf.stackName, 'application']),
       Subscription: [
         {
           Endpoint: cf.ref((options.destinations.sns ? 'ApplicationAlarmEmail' : 'ServiceAlarmEmail')),


### PR DESCRIPTION
@zmully I was getting an error from CFN when two SNS topics were named the same thing.  This varies the names.  