### PR TITLE
Updates npm badge to use new Mapbox scoped package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lambda-cfn
 
-[![Build Status](https://travis-ci.org/mapbox/lambda-cfn.svg?branch=master)](https://travis-ci.org/mapbox/lambda-cfn) [![npm](https://img.shields.io/npm/v/lambda-cfn.svg)](https://www.npmjs.com/package/lambda-cfn)
+[![Build Status](https://travis-ci.org/mapbox/lambda-cfn.svg?branch=master)](https://travis-ci.org/mapbox/lambda-cfn) [![npm](https://img.shields.io/npm/v/@mapbox/lambda-cfn.svg)](https://www.npmjs.com/package/@mapbox/lambda-cfn)
 
 Quickly create, deploy, and manage AWS Lambda functions via AWS CloudFormation.
 


### PR DESCRIPTION
We moved this package to the Mapbox scope on npm but we didn't update the npm badge in the README so it was still saying v1.0.0 instead of v2.0.0.

This PR fixes it. Going to merge this myself after creating this PR.