### PR TITLE
Don't lock NodeJS to a specific patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "license": "BSD-2-Clause",
   "engines": {
-    "node": "6.10.3"
+    "node": ">= 6.10.3"
   },
   "name": "@mapbox/lambda-cfn",
   "repository": {


### PR DESCRIPTION
Make required NodeJS version a little looser

@rclark could you give this a quick review?