### PR TITLE
fixed splitOnComma whitespace bug

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ function capitalizeFirst(s) {
 
 function splitOnComma(str) {
   if (str) {
-    return str.split(",").map(item => item.trim());
+    return str.split(',').map(item => item.trim());
   }
   // splitting unset parameter shouldn't return a non-falsey value
   return '';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ function capitalizeFirst(s) {
 
 function splitOnComma(str) {
   if (str) {
-    return str.split(/\s*,\s*/);
+    return str.split(",").map(item => item.trim());
   }
   // splitting unset parameter shouldn't return a non-falsey value
   return '';


### PR DESCRIPTION
Initially, splitOnComma on `"    foo , bar   , baz  "` would return `['    foo', 'bar', 'baz  ']`, now it correctly returns `['foo', 'bar', 'baz']`